### PR TITLE
Silence GCC15 deprecation warning raising errors in BoringSSL build

### DIFF
--- a/patches/boringssl.patch
+++ b/patches/boringssl.patch
@@ -1376,3 +1376,16 @@ index 6d46f886b..005b30f17 100644
 +  return set_sigalg_prefs(&ctx->delegated_credentials,
 +                          MakeConstSpan(sigalgs.data(), sigalgs.size()));
 +}
+diff --git a/third_party/googletest/googletest/include/gtest/internal/gtest-port.h b/third_party/googletest/googletest/include/gtest/internal/gtest-port.h
+index 4cfc16c03..0bbc208c0 100644
+--- a/third_party/googletest/googletest/include/gtest/internal/gtest-port.h
++++ b/third_party/googletest/googletest/include/gtest/internal/gtest-port.h
+@@ -282,7 +282,7 @@
+ 
+ // Detect C++ feature test macros as gracefully as possible.
+ // MSVC >= 19.15, Clang >= 3.4.1, and GCC >= 4.1.2 support feature test macros.
+-#if GTEST_INTERNAL_CPLUSPLUS_LANG >= 202002L && \
++#if GTEST_INTERNAL_CPLUSPLUS_LANG >= 201703L && \
+     (!defined(__has_include) || GTEST_INTERNAL_HAS_INCLUDE(<version>))
+ #include <version>  // C++20 and later
+ #elif (!defined(__has_include) || GTEST_INTERNAL_HAS_INCLUDE(<ciso646>))


### PR DESCRIPTION
Fixes #130