### PR TITLE
Add support for building binaries for Windows on ARM

### DIFF
--- a/.github/workflows/build-win.yaml
+++ b/.github/workflows/build-win.yaml
@@ -27,12 +27,13 @@ env:
 jobs:
   build-windows:
     name: Build windows binaries
-    runs-on: windows-latest
     strategy:
       matrix:
         include:
-          - { sys: vcvars64, env: x86_64 }
-          - { sys: vcvars32, env: i686 }
+          - { sys: vcvars64, env: x86_64, runner: windows-latest }
+          - { sys: vcvars32, env: i686, runner: windows-latest }
+          - { sys: vcvarsarm64, env: arm64, runner: windows-11-arm }
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: configure Pagefile
         uses: al-cheb/configure-pagefile-action@v1.3
@@ -41,10 +42,10 @@ jobs:
           maximum-size: 16GB
           disk-root: "C:"
 
-      - name: Install python 3.10
+      - name: Install python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -52,6 +53,14 @@ jobs:
       - name: Install NASM
         shell: cmd
         run: choco install nasm -y
+
+      - name: Install Ninja for Win-ARM64
+        shell: pwsh
+        if: matrix.os == 'windows-11-arm'
+        run: |
+          Invoke-WebRequest https://github.com/ninja-build/ninja/releases/download/v1.13.1/ninja-winarm64.zip -OutFile ninja-winarm64.zip
+          Expand-Archive ninja-winarm64.zip -DestinationPath ninja
+          Copy-Item ninja\ninja.exe -Destination "C:\Windows\System32"
 
       - name: Fetch and patch deps
         shell: bash
@@ -63,6 +72,8 @@ jobs:
       - name: Build
         shell: cmd
         run: ./win/build.bat ${{ matrix.sys }}
+        env:
+          DISABLE_ASM_ARM64: ${{ matrix.env == 'arm64' && 'true' || 'false' }}
 
       - name: Build tarball
         shell: bash

--- a/win/build.bat
+++ b/win/build.bat
@@ -55,8 +55,11 @@ popd
 
 :: Build & Install boringssl
 pushd "%deps%\boringssl"
-cmake %cmake_common_args% -DCMAKE_POSITION_INDEPENDENT_CODE=ON -S . -B "%build%\boringssl"
-cmake --build "%build%\boringssl" --config %configuration% --target install
+if "%DISABLE_ASM_ARM64%"=="true" (
+  cmake %cmake_common_args% -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DOPENSSL_NO_ASM=ON -S . -B "%build%\boringssl"
+) else (
+  cmake %cmake_common_args% -DCMAKE_POSITION_INDEPENDENT_CODE=ON -S . -B "%build%\boringssl"
+)
 popd
 
 :: Build & Install ngtcp2

--- a/win/build.bat
+++ b/win/build.bat
@@ -60,6 +60,7 @@ if "%DISABLE_ASM_ARM64%"=="true" (
 ) else (
   cmake %cmake_common_args% -DCMAKE_POSITION_INDEPENDENT_CODE=ON -S . -B "%build%\boringssl"
 )
+cmake --build "%build%\boringssl" --config %configuration% --target install
 popd
 
 :: Build & Install ngtcp2


### PR DESCRIPTION
PR description:
- The main motive of this PR is to add support for [curl_cffi](https://github.com/lexiforest/curl_cffi) python wheels for Windows on ARM(WoA).
- As part of this effort, currently curl_cffi internally [uses curl_impersonate](https://github.com/lexiforest/curl_cffi/blob/main/libs.json#L8) binary for building its wheels - Currently, the releases contains only Windows x64/x86 builds.
- The PR add support for building curl_impersonate on Windows on ARM natively with the following changes:
  - Added new native Windows on ARM github runner
  - Changed base python version from 3.10 ---> 3.11, since Python 3.10 is not available for WoA at this point.
  - The boringssl does not have implementation for arm with assembly which causing building errors by picking up wrong implementation from x86 - To fix this, I added cmake flag to avoid building assemblies on WoA
- Please feel free to ping if you have any suggestions/guidance to make curl_cffi and curl_impersonate more accessible for this growing platform