### PR TITLE
Add Chrome 149 impersonation target

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The following browsers can be impersonated. For a full list of browser profiles,
 | ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 142 | macOS Tahoe | `chrome142` | [curl_chrome142](bin/curl_chrome142) |
 | ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 145 | macOS Tahoe | `chrome145` | [curl_chrome145](bin/curl_chrome145) | ✅ |
 | ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 146 | macOS Tahoe | `chrome146` | [curl_chrome146](bin/curl_chrome146) | ✅ |
+| ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 149 | macOS Tahoe | `chrome149` | [curl_chrome149](bin/curl_chrome149) |
 | ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 99 | Android 12 | `chrome99_android` | [curl_chrome99_android](bin/curl_chrome99_android) |
 | ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 131 | Android 14 | `chrome131_android` | [curl_chrome131_android](bin/curl_chrome131_android) |
 | ![Edge](https://raw.githubusercontent.com/alrra/browser-logos/main/src/edge/edge_24x24.png "Edge") | 99 | Windows 10 | `edge99` | [curl_edge99](bin/curl_edge99) |

--- a/bin/curl_chrome149
+++ b/bin/curl_chrome149
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Find the directory of this script
+dir=${0%/*}
+
+"$dir/curl-impersonate" --compressed --impersonate "chrome149" "$@"

--- a/patches/curl.patch
+++ b/patches/curl.patch
@@ -2847,7 +2847,7 @@ new file mode 100644
 index 0000000000..928315b46b
 --- /dev/null
 +++ b/lib/impersonate.c
-@@ -0,0 +1,2282 @@
+@@ -0,0 +1,2360 @@
 +#include "curl_setup.h"
 +#include <curl/curl.h>
 +#include "impersonate.h"
@@ -3781,6 +3781,84 @@ index 0000000000..928315b46b
 +      "sec-ch-ua-platform: \"macOS\"",
 +      "Upgrade-Insecure-Requests: 1",
 +      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br, zstd",
++      "Accept-Language: en-US,en;q=0.9",
++      "Priority: u=0, i"
++    },
++    .http2_settings = "1:65536;2:0;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .http3_settings = "1:65536;6:262144;7:100;51:1;GREASE",
++    .http3_pseudo_headers_order = "masp",
++    .quic_transport_parameters = "1:30000;3:1472;4:15728640;5:6291456;6:6291456;7:6291456;8:100;9:103;15:;17:1@1,GREASE;32:65536;12583:AUTO;12584:0x4f524947;GREASE",
++    .http3_tls_extension_order = "0-10-13-16-27-43-45-51-57-17613-65037",
++    .ech = "true",
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = true,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true,
++    .split_cookies = true,
++    .form_boundary = "webkit",
++  },
++  {
++    .target = "chrome149",
++    .alias = "chrome149",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++      "TLS_AES_128_GCM_SHA256:"
++      "TLS_AES_256_GCM_SHA384:"
++      "TLS_CHACHA20_POLY1305_SHA256:"
++      "ECDHE-ECDSA-AES128-GCM-SHA256:"
++      "ECDHE-RSA-AES128-GCM-SHA256:"
++      "ECDHE-ECDSA-AES256-GCM-SHA384:"
++      "ECDHE-RSA-AES256-GCM-SHA384:"
++      "ECDHE-ECDSA-CHACHA20-POLY1305:"
++      "ECDHE-RSA-CHACHA20-POLY1305:"
++      "ECDHE-RSA-AES128-SHA:"
++      "ECDHE-RSA-AES256-SHA:"
++      "AES128-GCM-SHA256:"
++      "AES256-GCM-SHA384:"
++      "AES128-SHA:"
++      "AES256-SHA",
++    .curves = "X25519MLKEM768:X25519:P-256:P-384",
++    .sig_hash_algs =
++      "ecdsa_secp256r1_sha256:"
++      "rsa_pss_rsae_sha256:"
++      "rsa_pkcs1_sha256:"
++      "ecdsa_secp384r1_sha384:"
++      "rsa_pss_rsae_sha384:"
++      "rsa_pkcs1_sha384:"
++      "rsa_pss_rsae_sha512:"
++      "rsa_pkcs1_sha512",
++    .http3_sig_hash_algs =
++      "ecdsa_secp256r1_sha256:"
++      "rsa_pss_rsae_sha256:"
++      "rsa_pkcs1_sha256:"
++      "ecdsa_secp384r1_sha384:"
++      "rsa_pss_rsae_sha384:"
++      "rsa_pkcs1_sha384:"
++      "rsa_pss_rsae_sha512:"
++      "rsa_pkcs1_sha512:"
++      "rsa_pkcs1_sha1",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_permute_extensions = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \"Google Chrome\";v=\"149\", \"Chromium\";v=\"149\", \"Not)A;Brand\";v=\"24\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"macOS\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36",
 +      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
 +      "Sec-Fetch-Site: none",
 +      "Sec-Fetch-Mode: navigate",

--- a/tests/signatures/chrome_149.0.7827.102.yaml
+++ b/tests/signatures/chrome_149.0.7827.102.yaml
@@ -1,0 +1,153 @@
+# TLS ClientHello + HTTP/2 signature for Chrome 149 on macOS.
+#
+# Captured from a real Chrome 149 (build 149.0.7827.x) via https://tls.peet.ws/api/all:
+#   JA3 hash  c8993abafe571b0a8117dc2ac407cbd5
+#   JA4       t13d1516h2_8daaf6152771_d8a2da3f94cd
+#   Akamai H2 52d84b11737d980aef856699f885ca86
+#   PeetPrint 1d4ffe9b0e34acac0bd883fa7f79d7b5
+#
+# The TLS ClientHello (ciphers, curves, extension set, signature_algorithms) is
+# byte-identical to Chrome 142/146 already in this repo. It is NOT the same as
+# Chrome 150, which prepends the ML-DSA sig algs 2308-2309-2310.
+browser:
+  name: chrome
+  os: macOS
+  version: 149.0.7827.102
+signature:
+  options:
+    tls_permute_extensions: true
+  http2:
+    frames:
+    - frame_type: SETTINGS
+      settings:
+      - key: 1
+        value: 65536
+      - key: 2
+        value: 0
+      - key: 4
+        value: 6291456
+      - key: 6
+        value: 262144
+      stream_id: 0
+    - frame_type: WINDOW_UPDATE
+      stream_id: 0
+      window_size_increment: 15663105
+    - frame_type: HEADERS
+      headers:
+      - 'sec-ch-ua: "Google Chrome";v="149", "Chromium";v="149", "Not)A;Brand";v="24"'
+      - 'sec-ch-ua-mobile: ?0'
+      - 'sec-ch-ua-platform: "macOS"'
+      - 'upgrade-insecure-requests: 1'
+      - 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36'
+      - 'accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7'
+      - 'sec-fetch-site: none'
+      - 'sec-fetch-mode: navigate'
+      - 'sec-fetch-user: ?1'
+      - 'sec-fetch-dest: document'
+      - 'accept-encoding: gzip, deflate, br, zstd'
+      - 'accept-language: en-US,en;q=0.9'
+      - 'priority: u=0, i'
+      pseudo_headers:
+      - :method
+      - :authority
+      - :scheme
+      - :path
+      stream_id: 1
+  tls_client_hello:
+    ciphersuites:
+    - GREASE
+    - 4865
+    - 4866
+    - 4867
+    - 49195
+    - 49199
+    - 49196
+    - 49200
+    - 52393
+    - 52392
+    - 49171
+    - 49172
+    - 156
+    - 157
+    - 47
+    - 53
+    comp_methods:
+    - 0
+    extensions:
+    - length: 0
+      type: GREASE
+    - alps_alpn_list:
+      - h2
+      length: 5
+      type: application_settings_new
+    - length: 2
+      psk_ke_mode: 1
+      type: psk_key_exchange_modes
+    - algorithms:
+      - 2
+      length: 3
+      type: compress_certificate
+    - key_shares:
+      - group: GREASE
+        length: 1
+      - group: 4588
+        length: 1216
+      - group: 29
+        length: 32
+      length: 1263
+      type: keyshare
+    - length: 7
+      supported_versions:
+      - GREASE
+      - TLS_VERSION_1_3
+      - TLS_VERSION_1_2
+      type: supported_versions
+    - length: 1
+      type: renegotiation_info
+    - length: 0
+      type: encrypted_client_hello
+    - length: 0
+      type: extended_master_secret
+    - ec_point_formats:
+      - 0
+      length: 2
+      type: ec_point_formats
+    - length: 5
+      status_request_type: 1
+      type: status_request
+    - length: 0
+      type: session_ticket
+    - length: 12
+      supported_groups:
+      - GREASE
+      - 4588
+      - 29
+      - 23
+      - 24
+      type: supported_groups
+    - length: 0
+      type: signed_certificate_timestamp
+    - alpn_list:
+      - h2
+      - http/1.1
+      length: 14
+      type: application_layer_protocol_negotiation
+    - length: 18
+      sig_hash_algs:
+      - 1027
+      - 2052
+      - 1025
+      - 1283
+      - 2053
+      - 1281
+      - 2054
+      - 1537
+      type: signature_algorithms
+    - type: server_name
+    - data: !!binary |
+        AA==
+      length: 1
+      type: GREASE
+    handshake_version: TLS_VERSION_1_2
+    record_version: TLS_VERSION_1_0
+    session_id_length: 32

--- a/tests/targets.yaml
+++ b/tests/targets.yaml
@@ -59,6 +59,10 @@
   - null
   - null
   - chrome_142.0.7444.176_macOS
+- - curl_chrome149
+  - null
+  - null
+  - chrome_149.0.7827.102_macOS
 - - curl_chrome131_android
   - null
   - null
@@ -187,6 +191,10 @@
   - CURL_IMPERSONATE: chrome136
   - libcurl-impersonate
   - chrome_136.0.7103.93_macOS
+- - minicurl
+  - CURL_IMPERSONATE: chrome149
+  - libcurl-impersonate
+  - chrome_149.0.7827.102_macOS
 - - minicurl
   - CURL_IMPERSONATE: chrome131_android
   - libcurl-impersonate


### PR DESCRIPTION
## Summary
- Adds a `chrome149` impersonation target (macOS), following the repo's modern-Chrome convention.
- TLS ClientHello is byte-identical to the existing `chrome142`/`chrome146` profile — verified against a real Chrome 149 capture from `tls.peet.ws/api/all` (JA4 `t13d1516h2_8daaf6152771_d8a2da3f94cd`, Akamai H2 `52d84b11737d980aef856699f885ca86`). Only the version string and the captured `sec-ch-ua` brand token differ.

## Remaining step (draft)
This PR intentionally omits the `lib/impersonate.c` struct in `patches/curl.patch`, which must be regenerated during a build (add struct to source → rebuild → re-diff) rather than hand-edited. Until it lands, `--impersonate chrome149` doesn't exist and the signature tests will fail. The struct to add is a clone of the `chrome146` entry with:
- `.target`/`.alias` = `chrome149`
- `User-Agent: …Chrome/149.0.0.0…` (macOS)
- `sec-ch-ua: "Google Chrome";v="149", "Chromium";v="149", "Not)A;Brand";v="24"`
- all TLS/HTTP2/HTTP3 fields unchanged from chrome146

Note: Chrome 150 is deliberately **not** included — it adds ML-DSA signature algorithms (`2308-2309-2310`) that `parse_sig_algs`/`kSignatureAlgorithmNames` don't yet support.
