### PR TITLE
Add chrome150 impersonation target

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -28,6 +28,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to DockerHub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The following browsers can be impersonated. For a full list of browser profiles,
 | ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 142 | macOS Tahoe | `chrome142` | [curl_chrome142](bin/curl_chrome142) |
 | ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 145 | macOS Tahoe | `chrome145` | [curl_chrome145](bin/curl_chrome145) | ✅ |
 | ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 146 | macOS Tahoe | `chrome146` | [curl_chrome146](bin/curl_chrome146) | ✅ |
+| ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 150 | macOS Tahoe | `chrome150` | [curl_chrome150](bin/curl_chrome150) | ✅ |
 | ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 99 | Android 12 | `chrome99_android` | [curl_chrome99_android](bin/curl_chrome99_android) |
 | ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 131 | Android 14 | `chrome131_android` | [curl_chrome131_android](bin/curl_chrome131_android) |
 | ![Edge](https://raw.githubusercontent.com/alrra/browser-logos/main/src/edge/edge_24x24.png "Edge") | 99 | Windows 10 | `edge99` | [curl_edge99](bin/curl_edge99) |

--- a/bin/curl_chrome150
+++ b/bin/curl_chrome150
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Find the directory of this script
+dir=${0%/*}
+
+"$dir/curl-impersonate" --compressed --impersonate "chrome150" "$@"

--- a/patches/curl.patch
+++ b/patches/curl.patch
@@ -3264,7 +3264,7 @@ new file mode 100644
 index 0000000000..928315b46b
 --- /dev/null
 +++ b/lib/impersonate.c
-@@ -0,0 +1,2282 @@
+@@ -0,0 +1,2363 @@
 +#include "curl_setup.h"
 +#include <curl/curl.h>
 +#include "impersonate.h"
@@ -4214,6 +4214,87 @@ index 0000000000..928315b46b
 +    .http3_settings = "1:65536;6:262144;7:100;51:1;GREASE",
 +    .http3_pseudo_headers_order = "masp",
 +    .quic_transport_parameters = "1:30000;3:1472;4:15728640;5:6291456;6:6291456;7:6291456;8:100;9:103;15:;17:1@1,GREASE;32:65536;12583:AUTO;12584:0x4f524947;GREASE",
++    .http3_tls_extension_order = "0-10-13-16-27-43-45-51-57-17613-65037",
++    .ech = "true",
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = true,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true,
++    .split_cookies = true,
++    .form_boundary = "webkit",
++  },
++  {
++    .target = "chrome150",
++    .alias = "chrome150",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++      "TLS_AES_128_GCM_SHA256:"
++      "TLS_AES_256_GCM_SHA384:"
++      "TLS_CHACHA20_POLY1305_SHA256:"
++      "ECDHE-ECDSA-AES128-GCM-SHA256:"
++      "ECDHE-RSA-AES128-GCM-SHA256:"
++      "ECDHE-ECDSA-AES256-GCM-SHA384:"
++      "ECDHE-RSA-AES256-GCM-SHA384:"
++      "ECDHE-ECDSA-CHACHA20-POLY1305:"
++      "ECDHE-RSA-CHACHA20-POLY1305:"
++      "ECDHE-RSA-AES128-SHA:"
++      "ECDHE-RSA-AES256-SHA:"
++      "AES128-GCM-SHA256:"
++      "AES256-GCM-SHA384:"
++      "AES128-SHA:"
++      "AES256-SHA",
++    .curves = "X25519MLKEM768:X25519:P-256:P-384",
++    .sig_hash_algs =
++      "mldsa44:"
++      "mldsa65:"
++      "mldsa87:"
++      "ecdsa_secp256r1_sha256:"
++      "rsa_pss_rsae_sha256:"
++      "rsa_pkcs1_sha256:"
++      "ecdsa_secp384r1_sha384:"
++      "rsa_pss_rsae_sha384:"
++      "rsa_pkcs1_sha384:"
++      "rsa_pss_rsae_sha512:"
++      "rsa_pkcs1_sha512",
++    .http3_sig_hash_algs =
++      "ecdsa_secp256r1_sha256:"
++      "rsa_pss_rsae_sha256:"
++      "rsa_pkcs1_sha256:"
++      "ecdsa_secp384r1_sha384:"
++      "rsa_pss_rsae_sha384:"
++      "rsa_pkcs1_sha384:"
++      "rsa_pss_rsae_sha512:"
++      "rsa_pkcs1_sha512:"
++      "rsa_pkcs1_sha1",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_permute_extensions = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \"Not;A=Brand\";v=\"8\", \"Chromium\";v=\"150\", \"Google Chrome\";v=\"150\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"macOS\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br, zstd",
++      "Accept-Language: en-US,en;q=0.9",
++      "Priority: u=0, i"
++    },
++    .http2_settings = "1:65536;2:0;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .http3_settings = "1:65536;6:262144;7:100;51:1;GREASE",
++    .http3_pseudo_headers_order = "masp",
++    .quic_transport_parameters = "1:30000;3:1472;4:15728640;5:6291456;6:6291456;7:6291456;8:100;9:103;15:;17:1@1,GREASE;32:65536;12584:0x4f524947;GREASE",
 +    .http3_tls_extension_order = "0-10-13-16-27-43-45-51-57-17613-65037",
 +    .ech = "true",
 +    .tls_extension_order = NULL,

--- a/patches/curl.patch
+++ b/patches/curl.patch
@@ -784,7 +784,7 @@ index 0000000000..bc1a07122f
 +git df curl-8_21_0 -- . ':(exclude)tests/**' > chrome.patch
 +mv chrome.patch ../curl-impersonate/patches/curl.patch
 diff --git a/include/curl/curl.h b/include/curl/curl.h
-index 7e59e43c4d..0310d464e7 100644
+index 7e59e43c4d..7cbafd11f8 100644
 --- a/include/curl/curl.h
 +++ b/include/curl/curl.h
 @@ -185,6 +185,10 @@ typedef enum {
@@ -798,7 +798,7 @@ index 7e59e43c4d..0310d464e7 100644
  struct curl_httppost {
    struct curl_httppost *next;       /* next entry in the list */
    char *name;                       /* pointer to allocated name */
-@@ -2262,6 +2266,153 @@ typedef enum {
+@@ -2262,6 +2266,156 @@ typedef enum {
    /* set TLS supported signature algorithms */
    CURLOPT(CURLOPT_SSL_SIGNATURE_ALGORITHMS, CURLOPTTYPE_STRINGPOINT, 328),
  
@@ -949,10 +949,13 @@ index 7e59e43c4d..0310d464e7 100644
 +  /* curl-impersonate: WebSocket-specific TLS certificate compression. */
 +  CURLOPT(CURLOPT_WS_SSL_CERT_COMPRESSION, CURLOPTTYPE_STRINGPOINT, 1037),
 +
++  /* curl-impersonate: QUIC initial connection ID length profile. */
++  CURLOPT(CURLOPT_QUIC_CID_LENGTH, CURLOPTTYPE_STRINGPOINT, 1038),
++
    CURLOPT_LASTENTRY /* the last unused */
  } CURLoption;
  
-@@ -2996,7 +3147,14 @@ typedef enum {
+@@ -2996,7 +3150,14 @@ typedef enum {
    CURLINFO_HTTPAUTH_USED    = CURLINFO_LONG + 69,
    CURLINFO_PROXYAUTH_USED   = CURLINFO_LONG + 70,
    CURLINFO_SIZE_DELIVERED   = CURLINFO_OFF_T + 71,
@@ -1004,10 +1007,10 @@ index 197e6e7b92..8e0659ca66 100644
   * NAME curl_easy_getinfo()
   *
 diff --git a/include/curl/typecheck-gcc.h b/include/curl/typecheck-gcc.h
-index d600c73cdc..66543d62d6 100644
+index d600c73cdc..86a58c6088 100644
 --- a/include/curl/typecheck-gcc.h
 +++ b/include/curl/typecheck-gcc.h
-@@ -428,8 +428,22 @@ CURLWARNING(Wcurl_easy_getinfo_err_curl_off_t,
+@@ -428,8 +428,23 @@ CURLWARNING(Wcurl_easy_getinfo_err_curl_off_t,
     (option) == CURLOPT_FTP_ACCOUNT ||                                   \
     (option) == CURLOPT_FTP_ALTERNATIVE_TO_USER ||                       \
     (option) == CURLOPT_FTPPORT ||                                       \
@@ -1024,13 +1027,14 @@ index d600c73cdc..66543d62d6 100644
 +   (option) == CURLOPT_HTTP3_SIG_HASH_ALGS ||                           \
 +   (option) == CURLOPT_HTTP3_SSL_EC_CURVES ||                           \
 +   (option) == CURLOPT_HTTP3_TLS_EXTENSION_ORDER ||                     \
++   (option) == CURLOPT_QUIC_CID_LENGTH ||                               \
 +   (option) == CURLOPT_QUIC_TRANSPORT_PARAMETERS ||                     \
 +   (option) == CURLOPT_WS_HTTPHEADER_ORDER ||                           \
 +   (option) == CURLOPT_WS_SSL_CERT_COMPRESSION ||                       \
     (option) == CURLOPT_INTERFACE ||                                     \
     (option) == CURLOPT_ISSUERCERT ||                                    \
     (option) == CURLOPT_KEYPASSWD ||                                     \
-@@ -546,6 +560,8 @@ CURLWARNING(Wcurl_easy_getinfo_err_curl_off_t,
+@@ -546,6 +561,8 @@ CURLWARNING(Wcurl_easy_getinfo_err_curl_off_t,
  #define curlcheck_slist_option(option)                                  \
    ((option) == CURLOPT_HTTP200ALIASES ||                                \
     (option) == CURLOPT_HTTPHEADER ||                                    \
@@ -1039,7 +1043,7 @@ index d600c73cdc..66543d62d6 100644
     (option) == CURLOPT_MAIL_RCPT ||                                     \
     (option) == CURLOPT_POSTQUOTE ||                                     \
     (option) == CURLOPT_PREQUOTE ||                                      \
-@@ -574,7 +590,9 @@ CURLWARNING(Wcurl_easy_getinfo_err_curl_off_t,
+@@ -574,7 +591,9 @@ CURLWARNING(Wcurl_easy_getinfo_err_curl_off_t,
  /* true if info expects a pointer to struct curl_slist * argument */
  #define curlcheck_slist_info(info)                                      \
    (((info) == CURLINFO_SSL_ENGINES) ||                                  \
@@ -1157,6 +1161,30 @@ index 266ba52af3..54608e8cc2 100644
    ldap.c             \
    llist.c            \
    macos.c            \
+diff --git a/lib/cf-ip-happy.c b/lib/cf-ip-happy.c
+index 963ccea94d..2b9691fdcc 100644
+--- a/lib/cf-ip-happy.c
++++ b/lib/cf-ip-happy.c
+@@ -479,14 +479,14 @@ evaluate:
+       CURL_TRC_CF(data, cf, "check for next A address: %s",
+                   ai ? "found" : "none");
+     }
+-    /* We are (re-)starting attempts. We are not interested in
+-     * keeping old failure information. The new attempt will either
+-     * succeed or persist new failure. */
+-    Curl_reset_fail(data);
+-
+     if(ai) {  /* try another address */
+       struct Curl_sockaddr_ex addr;
+ 
++      /* We are (re-)starting attempts. We are not interested in
++       * keeping old failure information. The new attempt will either
++       * succeed or persist new failure. */
++      Curl_reset_fail(data);
++
+       /* Discard oldest to make room for new attempt */
+       if(bs->max_concurrent)
+         cf_ip_ballers_prune(bs, cf, data, bs->max_concurrent - 1);
 diff --git a/lib/cf-setup.c b/lib/cf-setup.c
 index 119294a89a..f603800a1a 100644
 --- a/lib/cf-setup.c
@@ -1431,7 +1459,7 @@ index d5337eb353..b2fb669979 100644
  /**
   * Return the n-th header entry or NULL if it does not exist.
 diff --git a/lib/easy.c b/lib/easy.c
-index d60bdaed7b..fe9d1e7517 100644
+index d60bdaed7b..d7bcbfae0a 100644
 --- a/lib/easy.c
 +++ b/lib/easy.c
 @@ -70,10 +70,14 @@
@@ -1449,7 +1477,7 @@ index d60bdaed7b..fe9d1e7517 100644
  
  #include "easy_lock.h"
  
-@@ -323,6 +327,389 @@ CURLsslset curl_global_sslset(curl_sslbackend id, const char *name,
+@@ -323,6 +327,396 @@ CURLsslset curl_global_sslset(curl_sslbackend id, const char *name,
    return rc;
  }
  
@@ -1650,6 +1678,13 @@ index d60bdaed7b..fe9d1e7517 100644
 +      return ret;
 +  }
 +
++  if(opts->quic_cid_length) {
++    ret = curl_easy_setopt(data, CURLOPT_QUIC_CID_LENGTH,
++                           opts->quic_cid_length);
++    if(ret)
++      return ret;
++  }
++
 +  if(opts->quic_transport_parameters) {
 +    ret = curl_easy_setopt(data, CURLOPT_QUIC_TRANSPORT_PARAMETERS,
 +                           opts->quic_transport_parameters);
@@ -1839,7 +1874,7 @@ index d60bdaed7b..fe9d1e7517 100644
  /*
   * curl_easy_init() is the external interface to alloc, setup and init an
   * easy handle that is returned. If anything goes wrong, NULL is returned.
-@@ -331,6 +718,8 @@ CURL *curl_easy_init(void)
+@@ -331,6 +725,8 @@ CURL *curl_easy_init(void)
  {
    CURLcode result;
    struct Curl_easy *data;
@@ -1848,7 +1883,7 @@ index d60bdaed7b..fe9d1e7517 100644
  
    /* Make sure we inited the global SSL stuff */
    global_init_lock();
-@@ -353,6 +742,30 @@ CURL *curl_easy_init(void)
+@@ -353,6 +749,30 @@ CURL *curl_easy_init(void)
      return NULL;
    }
  
@@ -1879,7 +1914,7 @@ index d60bdaed7b..fe9d1e7517 100644
    return data;
  }
  
-@@ -1027,6 +1440,13 @@ CURL *curl_easy_duphandle(CURL *curl)
+@@ -1027,6 +1447,13 @@ CURL *curl_easy_duphandle(CURL *curl)
        goto fail;
    }
  
@@ -1893,7 +1928,7 @@ index d60bdaed7b..fe9d1e7517 100644
    /* Reinitialize an SSL engine for the new handle
     * note: the engine name has already been copied by dupset */
    if(outcurl->set.str[STRING_SSL_ENGINE]) {
-@@ -1088,6 +1508,9 @@ fail:
+@@ -1088,6 +1515,9 @@ fail:
   */
  void curl_easy_reset(CURL *curl)
  {
@@ -1903,7 +1938,7 @@ index d60bdaed7b..fe9d1e7517 100644
    struct Curl_easy *data = curl;
    if(!GOOD_EASY_HANDLE(data))
      return;
-@@ -1120,6 +1543,23 @@ void curl_easy_reset(CURL *curl)
+@@ -1120,6 +1550,23 @@ void curl_easy_reset(CURL *curl)
    Curl_http_auth_cleanup_digest(data);
  #endif
    data->master_mid = UINT32_MAX;
@@ -1928,7 +1963,7 @@ index d60bdaed7b..fe9d1e7517 100644
  
  /*
 diff --git a/lib/easyoptions.c b/lib/easyoptions.c
-index 4c0b4f0ce4..31afae471b 100644
+index 4c0b4f0ce4..cac1841bd3 100644
 --- a/lib/easyoptions.c
 +++ b/lib/easyoptions.c
 @@ -99,6 +99,7 @@ const struct curl_easyoption Curl_easyopts[] = {
@@ -1984,16 +2019,17 @@ index 4c0b4f0ce4..31afae471b 100644
    { "PROXY_CRLFILE", CURLOPT_PROXY_CRLFILE, CURLOT_STRING, 0 },
    { "PROXY_ISSUERCERT", CURLOPT_PROXY_ISSUERCERT, CURLOT_STRING, 0 },
    { "PROXY_ISSUERCERT_BLOB", CURLOPT_PROXY_ISSUERCERT_BLOB, CURLOT_BLOB, 0 },
-@@ -251,6 +273,8 @@ const struct curl_easyoption Curl_easyopts[] = {
+@@ -251,6 +273,9 @@ const struct curl_easyoption Curl_easyopts[] = {
    { "PROXY_TRANSFER_MODE", CURLOPT_PROXY_TRANSFER_MODE, CURLOT_LONG, 0 },
    { "PUT", CURLOPT_PUT, CURLOT_LONG, 0 },
    { "QUICK_EXIT", CURLOPT_QUICK_EXIT, CURLOT_LONG, 0 },
++  { "QUIC_CID_LENGTH", CURLOPT_QUIC_CID_LENGTH, CURLOT_STRING, 0 },
 +  { "QUIC_TRANSPORT_PARAMETERS", CURLOPT_QUIC_TRANSPORT_PARAMETERS,
 +    CURLOT_STRING, 0 },
    { "QUOTE", CURLOPT_QUOTE, CURLOT_SLIST, 0 },
    { "RANDOM_FILE", CURLOPT_RANDOM_FILE, CURLOT_STRING, 0 },
    { "RANGE", CURLOPT_RANGE, CURLOT_STRING, 0 },
-@@ -289,6 +313,7 @@ const struct curl_easyoption Curl_easyopts[] = {
+@@ -289,6 +314,7 @@ const struct curl_easyoption Curl_easyopts[] = {
    { "SOCKS5_GSSAPI_NEC", CURLOPT_SOCKS5_GSSAPI_NEC, CURLOT_LONG, 0 },
    { "SOCKS5_GSSAPI_SERVICE", CURLOPT_SOCKS5_GSSAPI_SERVICE,
      CURLOT_STRING, 0 },
@@ -2001,7 +2037,7 @@ index 4c0b4f0ce4..31afae471b 100644
    { "SSH_AUTH_TYPES", CURLOPT_SSH_AUTH_TYPES, CURLOT_VALUES, 0 },
    { "SSH_COMPRESSION", CURLOPT_SSH_COMPRESSION, CURLOT_LONG, 0 },
    { "SSH_HOSTKEYDATA", CURLOPT_SSH_HOSTKEYDATA, CURLOT_CBPTR, 0 },
-@@ -313,23 +338,30 @@ const struct curl_easyoption Curl_easyopts[] = {
+@@ -313,23 +339,30 @@ const struct curl_easyoption Curl_easyopts[] = {
    { "SSLKEYTYPE", CURLOPT_SSLKEYTYPE, CURLOT_STRING, 0 },
    { "SSLKEY_BLOB", CURLOPT_SSLKEY_BLOB, CURLOT_BLOB, 0 },
    { "SSLVERSION", CURLOPT_SSLVERSION, CURLOT_VALUES, 0 },
@@ -2032,7 +2068,7 @@ index 4c0b4f0ce4..31afae471b 100644
    { "STREAM_WEIGHT", CURLOPT_STREAM_WEIGHT, CURLOT_LONG, 0 },
    { "SUPPRESS_CONNECT_HEADERS", CURLOPT_SUPPRESS_CONNECT_HEADERS,
      CURLOT_LONG, 0 },
-@@ -351,6 +383,19 @@ const struct curl_easyoption Curl_easyopts[] = {
+@@ -351,6 +384,19 @@ const struct curl_easyoption Curl_easyopts[] = {
    { "TLSAUTH_PASSWORD", CURLOPT_TLSAUTH_PASSWORD, CURLOT_STRING, 0 },
    { "TLSAUTH_TYPE", CURLOPT_TLSAUTH_TYPE, CURLOT_STRING, 0 },
    { "TLSAUTH_USERNAME", CURLOPT_TLSAUTH_USERNAME, CURLOT_STRING, 0 },
@@ -2052,7 +2088,7 @@ index 4c0b4f0ce4..31afae471b 100644
    { "TRAILERDATA", CURLOPT_TRAILERDATA, CURLOT_CBPTR, 0 },
    { "TRAILERFUNCTION", CURLOPT_TRAILERFUNCTION, CURLOT_FUNCTION, 0 },
    { "TRANSFERTEXT", CURLOPT_TRANSFERTEXT, CURLOT_LONG, 0 },
-@@ -371,7 +416,12 @@ const struct curl_easyoption Curl_easyopts[] = {
+@@ -371,7 +417,12 @@ const struct curl_easyoption Curl_easyopts[] = {
    { "WRITEDATA", CURLOPT_WRITEDATA, CURLOT_CBPTR, 0 },
    { "WRITEFUNCTION", CURLOPT_WRITEFUNCTION, CURLOT_FUNCTION, 0 },
    { "WRITEHEADER", CURLOPT_HEADERDATA, CURLOT_CBPTR, CURLOT_FLAG_ALIAS },
@@ -2065,12 +2101,12 @@ index 4c0b4f0ce4..31afae471b 100644
    { "XFERINFODATA", CURLOPT_XFERINFODATA, CURLOT_CBPTR, 0 },
    { "XFERINFOFUNCTION", CURLOPT_XFERINFOFUNCTION, CURLOT_FUNCTION, 0 },
    { "XOAUTH2_BEARER", CURLOPT_XOAUTH2_BEARER, CURLOT_STRING, 0 },
-@@ -385,6 +435,6 @@ const struct curl_easyoption Curl_easyopts[] = {
+@@ -385,6 +436,6 @@ const struct curl_easyoption Curl_easyopts[] = {
   */
  int Curl_easyopts_check(void)
  {
 -  return (CURLOPT_LASTENTRY % 10000) != (328 + 1);
-+  return (CURLOPT_LASTENTRY % 10000) != (1037 + 1);
++  return (CURLOPT_LASTENTRY % 10000) != (1038 + 1);
  }
  #endif
 diff --git a/lib/getinfo.c b/lib/getinfo.c
@@ -3261,10 +3297,10 @@ index e38dc5745c..95921f5a99 100644
   * Store nghttp2 version info in this buffer.
 diff --git a/lib/impersonate.c b/lib/impersonate.c
 new file mode 100644
-index 0000000000..928315b46b
+index 0000000000..0bc9cc1416
 --- /dev/null
 +++ b/lib/impersonate.c
-@@ -0,0 +1,2363 @@
+@@ -0,0 +1,2367 @@
 +#include "curl_setup.h"
 +#include <curl/curl.h>
 +#include "impersonate.h"
@@ -4135,6 +4171,7 @@ index 0000000000..928315b46b
 +    .http2_stream_exclusive = 1,
 +    .http3_settings = "1:65536;6:262144;7:100;51:1;GREASE",
 +    .http3_pseudo_headers_order = "masp",
++    .quic_cid_length = "webkit",
 +    .quic_transport_parameters = "1:30000;3:1472;4:15728640;5:6291456;6:6291456;7:6291456;8:100;9:103;15:;17:1@1,GREASE;32:65536;12583:AUTO;18258:1;GREASE",
 +    .http3_tls_extension_order = "0-10-13-16-27-43-45-51-57-17613-65037",
 +    .ech = "true",
@@ -4213,6 +4250,7 @@ index 0000000000..928315b46b
 +    .http2_stream_exclusive = 1,
 +    .http3_settings = "1:65536;6:262144;7:100;51:1;GREASE",
 +    .http3_pseudo_headers_order = "masp",
++    .quic_cid_length = "webkit",
 +    .quic_transport_parameters = "1:30000;3:1472;4:15728640;5:6291456;6:6291456;7:6291456;8:100;9:103;15:;17:1@1,GREASE;32:65536;12583:AUTO;12584:0x4f524947;GREASE",
 +    .http3_tls_extension_order = "0-10-13-16-27-43-45-51-57-17613-65037",
 +    .ech = "true",
@@ -4294,6 +4332,7 @@ index 0000000000..928315b46b
 +    .http2_stream_exclusive = 1,
 +    .http3_settings = "1:65536;6:262144;7:100;51:1;GREASE",
 +    .http3_pseudo_headers_order = "masp",
++    .quic_cid_length = "webkit",
 +    .quic_transport_parameters = "1:30000;3:1472;4:15728640;5:6291456;6:6291456;7:6291456;8:100;9:103;15:;17:1@1,GREASE;32:65536;12584:0x4f524947;GREASE",
 +    .http3_tls_extension_order = "0-10-13-16-27-43-45-51-57-17613-65037",
 +    .ech = "true",
@@ -4769,6 +4808,7 @@ index 0000000000..928315b46b
 +    .http2_stream_weight = 42,
 +    .http3_settings = "1:65536;7:20;727725890:0;16765559:1;51:1;8:1",
 +    .http3_pseudo_headers_order = "msap",
++    .quic_cid_length = "firefox",
 +    .quic_transport_parameters = "1:30000;4:25165824;5:12582912;6:1048576;7:1048576;8:100;9:100;11:20;14:8;15:AUTO;17:1@GREASE,1;GREASE;32:65535",
 +    .http3_tls_extension_order = "28-51-27-13-34-10-45-16-65281-23-5-0-43-57-65037",
 +    .cert_compression = "zlib,brotli,zstd",
@@ -5630,10 +5670,10 @@ index 0000000000..928315b46b
 +const size_t num_impersonations = sizeof(impersonations) / sizeof(impersonations[0]);
 diff --git a/lib/impersonate.h b/lib/impersonate.h
 new file mode 100644
-index 0000000000..d44b1fd0de
+index 0000000000..9d5547a0f6
 --- /dev/null
 +++ b/lib/impersonate.h
-@@ -0,0 +1,82 @@
+@@ -0,0 +1,83 @@
 +#ifndef HEADER_CURL_IMPERSONATE_H
 +#define HEADER_CURL_IMPERSONATE_H
 +
@@ -5686,6 +5726,7 @@ index 0000000000..d44b1fd0de
 +  const char *http2_streams;
 +  const char *http3_pseudo_headers_order;
 +  const char *http3_settings;
++  const char *quic_cid_length;
 +  const char *quic_transport_parameters;
 +  bool tls_permute_extensions;
 +  bool tls_use_new_alps_codepoint;
@@ -5913,7 +5954,7 @@ index 8d57c058c6..6725bbeaea 100644
  };
  
 diff --git a/lib/setopt.c b/lib/setopt.c
-index eb9ff2e396..2b78cb5947 100644
+index eb9ff2e396..0559b7de84 100644
 --- a/lib/setopt.c
 +++ b/lib/setopt.c
 @@ -46,8 +46,10 @@
@@ -6206,7 +6247,7 @@ index eb9ff2e396..2b78cb5947 100644
    case CURLOPT_SSL_SIGNATURE_ALGORITHMS:
      /*
       * Set accepted signature algorithms.
-@@ -2494,12 +2675,106 @@ static CURLcode setopt_cptr_misc(struct Curl_easy *data, CURLoption option,
+@@ -2494,12 +2675,110 @@ static CURLcode setopt_cptr_misc(struct Curl_easy *data, CURLoption option,
    return result;
  }
  
@@ -6277,6 +6318,10 @@ index eb9ff2e396..2b78cb5947 100644
 +    return Curl_setstropt(&s->str[STRING_HTTP3_PSEUDO_HEADERS_ORDER], ptr);
 +  case CURLOPT_HTTP3_SETTINGS:
 +    return Curl_setstropt(&s->str[STRING_HTTP3_SETTINGS], ptr);
++  case CURLOPT_QUIC_CID_LENGTH:
++    if(ptr && strcmp(ptr, "webkit") && strcmp(ptr, "firefox"))
++      return CURLE_BAD_FUNCTION_ARGUMENT;
++    return Curl_setstropt(&s->str[STRING_QUIC_CID_LENGTH], ptr);
 +  case CURLOPT_QUIC_TRANSPORT_PARAMETERS:
 +    return Curl_setstropt(&s->str[STRING_QUIC_TRANSPORT_PARAMETERS], ptr);
 +  case CURLOPT_HTTP3_SIG_HASH_ALGS:
@@ -6313,7 +6358,7 @@ index eb9ff2e396..2b78cb5947 100644
  #ifndef CURL_DISABLE_PROXY
      setopt_cptr_proxy,
  #endif
-@@ -2892,6 +3167,9 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
+@@ -2892,6 +3171,9 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
         way than being listed explicitly */
      switch(option) {
      case CURLOPT_HTTPHEADER:
@@ -7195,7 +7240,7 @@ index 505e08a7e1..ad8440dd9c 100644
        /* There is a connection that *might* become usable for multiplexing
           "soon", and we wait for that */
 diff --git a/lib/urldata.h b/lib/urldata.h
-index d4d336d8db..73de71edeb 100644
+index d4d336d8db..2a273f1c49 100644
 --- a/lib/urldata.h
 +++ b/lib/urldata.h
 @@ -193,6 +193,7 @@ struct ConnectBits {
@@ -7277,7 +7322,7 @@ index d4d336d8db..73de71edeb 100644
  #ifndef CURL_DISABLE_AWS
    STRING_AWS_SIGV4, /* Parameters for V4 signature */
  #endif
-@@ -875,6 +905,21 @@ enum dupstring {
+@@ -875,6 +905,22 @@ enum dupstring {
  #endif
    STRING_ECH_CONFIG,            /* CURLOPT_ECH_CONFIG */
    STRING_ECH_PUBLIC,            /* CURLOPT_ECH_PUBLIC */
@@ -7289,6 +7334,7 @@ index d4d336d8db..73de71edeb 100644
 +  STRING_HTTP2_STREAMS,
 +  STRING_HTTP3_PSEUDO_HEADERS_ORDER,
 +  STRING_HTTP3_SETTINGS,
++  STRING_QUIC_CID_LENGTH,
 +  STRING_QUIC_TRANSPORT_PARAMETERS,
 +  STRING_HTTPHEADER_ORDER,
 +  STRING_HTTP3_HTTPHEADER_ORDER,
@@ -7299,7 +7345,7 @@ index d4d336d8db..73de71edeb 100644
    STRING_SSL_SIGNATURE_ALGORITHMS, /* CURLOPT_SSL_SIGNATURE_ALGORITHMS */
  
    /* -- end of null-terminated strings -- */
-@@ -956,6 +1001,8 @@ struct UserDefined {
+@@ -956,6 +1002,8 @@ struct UserDefined {
                                  download */
    curl_off_t set_resume_from;  /* continue [ftp] transfer from here */
    struct curl_slist *headers; /* linked list of extra headers */
@@ -7308,7 +7354,7 @@ index d4d336d8db..73de71edeb 100644
    struct curl_httppost *httppost;  /* linked list of old POST data */
  #if !defined(CURL_DISABLE_MIME) || !defined(CURL_DISABLE_FORM_API)
    curl_mimepart *mimepostp;  /* MIME/POST data. */
-@@ -1117,6 +1164,7 @@ struct UserDefined {
+@@ -1117,6 +1165,7 @@ struct UserDefined {
    BIT(sep_headers);     /* handle host and proxy headers separately */
  #ifndef CURL_DISABLE_COOKIES
    BIT(cookiesession);   /* new cookie session? */
@@ -7316,7 +7362,7 @@ index d4d336d8db..73de71edeb 100644
  #endif
    BIT(crlf);            /* convert crlf on ftp upload(?) */
  #ifdef USE_SSH
-@@ -1133,6 +1181,7 @@ struct UserDefined {
+@@ -1133,6 +1182,7 @@ struct UserDefined {
    BIT(get_filetime);     /* get the time and get of the remote file */
  #ifndef CURL_DISABLE_PROXY
    BIT(tunnel_thru_httpproxy); /* use CONNECT through an HTTP proxy */
@@ -7324,7 +7370,7 @@ index d4d336d8db..73de71edeb 100644
  #endif
    BIT(prefer_ascii);     /* ASCII rather than binary */
    BIT(remote_append);    /* append, not overwrite, on upload */
-@@ -1175,7 +1224,17 @@ struct UserDefined {
+@@ -1175,7 +1225,17 @@ struct UserDefined {
    BIT(sasl_ir);         /* Enable/disable SASL initial response */
    BIT(tcp_keepalive);  /* use TCP keepalives */
    BIT(tcp_fastopen);   /* use TCP Fast Open */
@@ -7342,7 +7388,7 @@ index d4d336d8db..73de71edeb 100644
    BIT(path_as_is);     /* allow dotdots? */
    BIT(pipewait);       /* wait for multiplex status before starting a new
                            connection */
-@@ -1197,10 +1256,15 @@ struct UserDefined {
+@@ -1197,10 +1257,15 @@ struct UserDefined {
    BIT(doh_verifystatus);   /* DoH certificate status verification */
  #endif
    BIT(http09_allowed); /* allow HTTP/0.9 responses */
@@ -7359,7 +7405,7 @@ index d4d336d8db..73de71edeb 100644
    BIT(post302); /* keep POSTs as POSTs after a 302 request */
    BIT(post303); /* keep POSTs as POSTs after a 303 request */
 diff --git a/lib/vquic/cf-ngtcp2-cmn.c b/lib/vquic/cf-ngtcp2-cmn.c
-index e1ca18cf69..c41071390f 100644
+index e1ca18cf69..f60407ef7a 100644
 --- a/lib/vquic/cf-ngtcp2-cmn.c
 +++ b/lib/vquic/cf-ngtcp2-cmn.c
 @@ -63,6 +63,7 @@
@@ -8141,32 +8187,59 @@ index e1ca18cf69..c41071390f 100644
  }
  
  #if defined(_MSC_VER) && defined(_DLL)
-@@ -900,7 +1623,7 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
+@@ -898,31 +1621,60 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
+   int rc;
+   int rv;
    CURLcode result;
++  const char *cid_profile = data->set.str[STRING_QUIC_CID_LENGTH];
++  size_t dcidlen = NGTCP2_MAX_CIDLEN;
++  size_t scidlen = NGTCP2_MAX_CIDLEN;
    const struct Curl_sockaddr_ex *sockaddr = NULL;
    int qfd;
 -  static const struct alpn_spec ALPN_SPEC_H3 = { { "h3", "h3-29" }, 2 };
 +  static const struct alpn_spec ALPN_SPEC_H3 = { { "h3" }, 1 };
  
    DEBUGASSERT(ctx->initialized);
-   ctx->dcid.datalen = NGTCP2_MAX_CIDLEN;
-@@ -909,20 +1632,28 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
-     return result;
- 
-   ctx->scid.datalen = NGTCP2_MAX_CIDLEN;
--  result = Curl_rand(data, ctx->scid.data, NGTCP2_MAX_CIDLEN);
+-  ctx->dcid.datalen = NGTCP2_MAX_CIDLEN;
+-  result = Curl_rand(data, ctx->dcid.data, NGTCP2_MAX_CIDLEN);
 -  if(result)
 -    return result;
-+  if(quic_has_empty_initial_scid(
++  if(cid_profile) {
++    if(!strcmp(cid_profile, "webkit")) {
++      dcidlen = 8;
++      scidlen = 0;
++    }
++    else if(!strcmp(cid_profile, "firefox")) {
++      unsigned char v;
++
++      result = Curl_rand(data, &v, sizeof(v));
++      if(result)
++        return result;
++      dcidlen = 5 + (v & (v >> 4));
++      if(dcidlen < 8)
++        dcidlen = 8;
++      scidlen = 3;
++    }
++  }
+ 
+-  ctx->scid.datalen = NGTCP2_MAX_CIDLEN;
+-  result = Curl_rand(data, ctx->scid.data, NGTCP2_MAX_CIDLEN);
++  ctx->dcid.datalen = dcidlen;
++  result = Curl_rand(data, ctx->dcid.data, ctx->dcid.datalen);
+   if(result)
+     return result;
+ 
+-  (void)Curl_qlogdir(data, ctx->scid.data, NGTCP2_MAX_CIDLEN, &qfd);
++  ctx->scid.datalen = scidlen;
++  if(!cid_profile && quic_has_empty_initial_scid(
 +       data->set.str[STRING_QUIC_TRANSPORT_PARAMETERS]))
 +    ctx->scid.datalen = 0;
-+  else {
++  if(ctx->scid.datalen) {
 +    result = Curl_rand(data, ctx->scid.data, ctx->scid.datalen);
 +    if(result)
 +      return result;
 +  }
- 
--  (void)Curl_qlogdir(data, ctx->scid.data, NGTCP2_MAX_CIDLEN, &qfd);
++
 +  (void)Curl_qlogdir(data, ctx->scid.data, ctx->scid.datalen, &qfd);
    ctx->qlogfd = qfd; /* -1 if failure above */
 -  quic_settings(ctx, data, pktx);
@@ -8185,7 +8258,7 @@ index e1ca18cf69..c41071390f 100644
      /* No direct socket - must be tunneled QUIC (CONNECT-UDP through proxy) */
      ctx->q.sockfd = CURL_SOCKET_BAD;
    }
-@@ -952,6 +1683,7 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
+@@ -952,6 +1704,7 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
      ctx->conn_ref.get_conn = get_conn;
      ctx->conn_ref.user_data = cf;
    }
@@ -8193,7 +8266,7 @@ index e1ca18cf69..c41071390f 100644
    else {
      /* Tunneled QUIC (e.g. CONNECT-UDP): get remote address
         from the connected filter below */
-@@ -997,6 +1729,19 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
+@@ -997,6 +1750,19 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
      ctx->conn_ref.user_data = cf;
    }
  
@@ -8213,7 +8286,7 @@ index e1ca18cf69..c41071390f 100644
    result = Curl_vquic_tls_init(&ctx->tls, cf, data,
                                 &ctx->ssl_peer, &ALPN_SPEC_H3,
                                 cf_ngtcp2_tls_ctx_setup, &ctx->tls,
-@@ -1132,7 +1877,7 @@ out:
+@@ -1132,7 +1898,7 @@ out:
        /* Direct UDP socket - get IP info for error reporting */
        struct ip_quadruple ip;
  
@@ -8222,7 +8295,7 @@ index e1ca18cf69..c41071390f 100644
          infof(data, "QUIC connect to %s port %u failed: %s",
                ip.remote_ip, ip.remote_port, curl_easy_strerror(result));
      }
-@@ -1767,14 +2512,34 @@ CURLcode Curl_cf_ngtcp2_cmn_set_expiry(struct Curl_cfilter *cf,
+@@ -1767,14 +2533,34 @@ CURLcode Curl_cf_ngtcp2_cmn_set_expiry(struct Curl_cfilter *cf,
    return CURLE_OK;
  }
  
@@ -8261,7 +8334,7 @@ index e1ca18cf69..c41071390f 100644
     *
     * Some servers use this as a keep-alive timer at a rather low
     * value. We are doing HTTP/3 here and waiting for the response
-@@ -1784,10 +2549,10 @@ static void cf_ngtcp2_setup_keep_alive(struct Curl_cfilter *cf,
+@@ -1784,10 +2570,10 @@ static void cf_ngtcp2_setup_keep_alive(struct Curl_cfilter *cf,
    if(!ctx->qconn)
      return;
  
@@ -8275,7 +8348,7 @@ index e1ca18cf69..c41071390f 100644
    }
    else if(!Curl_uint32_hash_count(&ctx->streams)) {
      ngtcp2_conn_set_keep_alive_timeout(ctx->qconn, UINT64_MAX);
-@@ -1795,11 +2560,11 @@ static void cf_ngtcp2_setup_keep_alive(struct Curl_cfilter *cf,
+@@ -1795,11 +2581,11 @@ static void cf_ngtcp2_setup_keep_alive(struct Curl_cfilter *cf,
    }
    else {
      ngtcp2_duration keep_ns;
@@ -8290,7 +8363,7 @@ index e1ca18cf69..c41071390f 100644
                  (keep_ns / NGTCP2_MILLISECONDS));
    }
  }
-@@ -1885,7 +2650,10 @@ bool Curl_cf_ngtcp2_cmn_conn_is_alive(struct Curl_cfilter *cf,
+@@ -1885,7 +2671,10 @@ bool Curl_cf_ngtcp2_cmn_conn_is_alive(struct Curl_cfilter *cf,
  {
    struct cf_ngtcp2_ctx *ctx = cf->ctx;
    bool alive = FALSE;
@@ -8302,7 +8375,7 @@ index e1ca18cf69..c41071390f 100644
    struct cf_call_data save;
  
    CF_DATA_SAVE(save, cf, data);
-@@ -1893,18 +2661,19 @@ bool Curl_cf_ngtcp2_cmn_conn_is_alive(struct Curl_cfilter *cf,
+@@ -1893,18 +2682,19 @@ bool Curl_cf_ngtcp2_cmn_conn_is_alive(struct Curl_cfilter *cf,
    if(!ctx->qconn || ctx->shutdown_started)
      goto out;
  
@@ -8333,7 +8406,7 @@ index e1ca18cf69..c41071390f 100644
    }
  
    if(!cf->next || !cf->next->cft->is_alive(cf->next, data, input_pending))
-@@ -1921,6 +2690,11 @@ bool Curl_cf_ngtcp2_cmn_conn_is_alive(struct Curl_cfilter *cf,
+@@ -1921,6 +2711,11 @@ bool Curl_cf_ngtcp2_cmn_conn_is_alive(struct Curl_cfilter *cf,
      CURL_TRC_CF(data, cf, "is_alive, progress ingress -> %d", (int)result);
      alive = result ? FALSE : TRUE;
    }
@@ -8920,7 +8993,7 @@ index dfb8346c1a..602402e256 100644
    return CURLE_OK;
  }
 diff --git a/lib/vtls/openssl.c b/lib/vtls/openssl.c
-index 010bbb9825..a5bdd880be 100644
+index 010bbb9825..d6bfcf7abd 100644
 --- a/lib/vtls/openssl.c
 +++ b/lib/vtls/openssl.c
 @@ -68,9 +68,24 @@
@@ -9377,7 +9450,17 @@ index 010bbb9825..a5bdd880be 100644
    ciphers = conn_config->cipher_list;
    if(!ciphers && (peer->transport != TRNSPRT_QUIC))
      ciphers = NULL;
-@@ -3873,7 +4252,8 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
+@@ -3859,7 +4238,8 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
+ #endif
+ 
+   {
+-    const char *curves = conn_config->curves;
++    const char *curves =
++      Curl_ssl_config_get_curves(conn_config, peer->transport);
+     if(curves) {
+ #ifdef HAVE_BORINGSSL_LIKE
+ #define OSSL_CURVE_CAST(x) (x)
+@@ -3873,10 +4253,12 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
      }
    }
  
@@ -9386,8 +9469,13 @@ index 010bbb9825..a5bdd880be 100644
 +  !defined(OPENSSL_IS_BORINGSSL)
  #define OSSL_SIGALG_CAST(x) OSSL_CURVE_CAST(x)
    {
-     const char *signature_algorithms = conn_config->signature_algorithms;
-@@ -3888,6 +4268,34 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
+-    const char *signature_algorithms = conn_config->signature_algorithms;
++    const char *signature_algorithms =
++      Curl_ssl_config_get_signature_algorithms(conn_config, peer->transport);
+     if(signature_algorithms) {
+       if(!SSL_CTX_set1_sigalgs_list(octx->ssl_ctx,
+                                     OSSL_SIGALG_CAST(signature_algorithms))) {
+@@ -3888,6 +4270,35 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
    }
  #endif
  
@@ -9396,7 +9484,8 @@ index 010bbb9825..a5bdd880be 100644
 +    uint16_t algs[MAX_SIG_ALGS];
 +    size_t nalgs;
 +    /* curl-impersonate: Set the signature algorithms (TLS extension 13). */
-+    const char *signature_algorithms = conn_config->signature_algorithms;
++    const char *signature_algorithms =
++      Curl_ssl_config_get_signature_algorithms(conn_config, peer->transport);
 +    if(signature_algorithms) {
 +      CURLcode result = parse_sig_algs(data, signature_algorithms, algs,
 +                                       &nalgs);
@@ -9422,7 +9511,7 @@ index 010bbb9825..a5bdd880be 100644
  #if defined(HAVE_OPENSSL_SRP) && defined(USE_TLS_SRP)
    if(ssl_config->primary.username && Curl_auth_allowed_to_host(data)) {
      char * const ssl_username = ssl_config->primary.username;
-@@ -3913,6 +4321,56 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
+@@ -3913,6 +4324,63 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
    }
  #endif /* HAVE_OPENSSL_SRP && USE_TLS_SRP */
  
@@ -9447,9 +9536,16 @@ index 010bbb9825..a5bdd880be 100644
 +    SSL_CTX_set_permute_extensions(octx->ssl_ctx, 1);
 +
 +  /* curl-impersonate: Set TLS extensions order. */
-+  if(conn_config->tls_extension_order)
-+    SSL_CTX_set_extension_order(octx->ssl_ctx,
-+                                conn_config->tls_extension_order);
++  {
++    const char *extension_order = Curl_ssl_config_get_tls_extension_order(
++      conn_config, peer->transport);
++    if(extension_order &&
++       !SSL_CTX_set_extension_order(octx->ssl_ctx,
++                                    (char *)CURL_UNCONST(extension_order))) {
++      failf(data, "Invalid TLS extension order: '%s'", extension_order);
++      return CURLE_SSL_CONNECT_ERROR;
++    }
++  }
 +
 +  if(data->set.str[STRING_TLS_DELEGATED_CREDENTIALS])
 +    SSL_CTX_set_delegated_credentials(
@@ -9479,6 +9575,66 @@ index 010bbb9825..a5bdd880be 100644
    /* OpenSSL always tries to verify the peer. By setting the failure mode
     * to NONE, we allow the connect to complete, regardless of the outcome.
     * We then explicitly check the result and may try alternatives like
+@@ -4253,8 +4721,10 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
+ #endif
+       else {
+         result = CURLE_SSL_CONNECT_ERROR;
+-        failf(data, "TLS connect error: %s",
+-              ossl_strerror(errdetail, error_buffer, sizeof(error_buffer)));
++        if(errdetail)
++          failf(data, "TLS connect error: %s",
++                ossl_strerror(errdetail, error_buffer,
++                              sizeof(error_buffer)));
+       }
+ 
+       /* detail is already set to the SSL error above */
+@@ -4267,10 +4737,20 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
+         char extramsg[80] = "";
+         int sockerr = SOCKERRNO;
+ 
+-        if(sockerr && detail == SSL_ERROR_SYSCALL)
++        if(octx->io_result && octx->io_result != CURLE_AGAIN)
++          curl_msnprintf(extramsg, sizeof(extramsg), "%s",
++                         curl_easy_strerror(octx->io_result));
++        else if(connssl->peer_closed)
++          curl_msnprintf(extramsg, sizeof(extramsg),
++                         "Connection closed abruptly");
++        else if(sockerr && detail == SSL_ERROR_SYSCALL)
+           curlx_strerror(sockerr, extramsg, sizeof(extramsg));
+-        failf(data, OSSL_PACKAGE " SSL_connect: %s in connection to %s:%d ",
+-              extramsg[0] ? extramsg : SSL_ERROR_to_str(detail),
++        else
++          curl_msnprintf(extramsg, sizeof(extramsg),
++                         "no transport error details available");
++        failf(data, OSSL_PACKAGE " SSL_connect: %s (%s; error queue empty) "
++              "in connection to %s:%d",
++              extramsg, SSL_ERROR_to_str(detail),
+               connssl->peer.origin->hostname, connssl->peer.origin->port);
+       }
+ 
+@@ -4282,6 +4762,22 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
+     connssl->connecting_state = ssl_connect_3;
+     Curl_ossl_report_handshake(data, octx);
+ 
++#ifdef OPENSSL_IS_BORINGSSL
++    {
++      const unsigned char *neg_protocol;
++      unsigned int len;
++
++      SSL_get0_alpn_selected(octx->ssl, &neg_protocol, &len);
++      if(!len ||
++         (len == ALPN_HTTP_1_1_LENGTH &&
++          !memcmp(neg_protocol, ALPN_HTTP_1_1, len))) {
++        /* Chrome permits renegotiation for HTTP/1.1 connections. Limit it
++         * to one server-initiated renegotiation. */
++        SSL_set_renegotiate_mode(octx->ssl, ssl_renegotiate_once);
++      }
++    }
++#endif
++
+ #if defined(HAVE_SSL_SET1_ECH_CONFIG_LIST) && !defined(HAVE_BORINGSSL_LIKE)
+     if(CURLECH_ENABLED(data)) {
+       char *inner = NULL, *outer = NULL;
 diff --git a/lib/vtls/vtls.c b/lib/vtls/vtls.c
 index 82ce007b3d..7a7531c187 100644
 --- a/lib/vtls/vtls.c
@@ -9614,19 +9770,62 @@ index 96cb7d15ed..ca72a31d28 100644
   * Free all allocated data and reset peer information.
   */
 diff --git a/lib/vtls/vtls_config.c b/lib/vtls/vtls_config.c
-index 4a9b69654b..d3c73e598a 100644
+index 4a9b69654b..d9f7ca2d9f 100644
 --- a/lib/vtls/vtls_config.c
 +++ b/lib/vtls/vtls_config.c
-@@ -127,6 +127,8 @@ void Curl_ssl_config_cleanup(struct ssl_primary_config *sslc)
+@@ -112,6 +112,38 @@ void Curl_ssl_config_init(struct ssl_primary_config *sslc)
+   sslc->cache_session = TRUE; /* caching by default */
+ }
+ 
++static const char *ssl_config_get_transport_value(const char *value,
++                                                  const char *http3_value,
++                                                  uint8_t transport)
++{
++  if((transport == TRNSPRT_QUIC) && http3_value)
++    return http3_value;
++  return value;
++}
++
++const char *Curl_ssl_config_get_curves(
++  const struct ssl_primary_config *sslc, uint8_t transport)
++{
++  return ssl_config_get_transport_value(sslc->curves, sslc->http3_curves,
++                                        transport);
++}
++
++const char *Curl_ssl_config_get_signature_algorithms(
++  const struct ssl_primary_config *sslc, uint8_t transport)
++{
++  return ssl_config_get_transport_value(sslc->signature_algorithms,
++                                        sslc->http3_signature_algorithms,
++                                        transport);
++}
++
++const char *Curl_ssl_config_get_tls_extension_order(
++  const struct ssl_primary_config *sslc, uint8_t transport)
++{
++  return ssl_config_get_transport_value(sslc->tls_extension_order,
++                                        sslc->http3_tls_extension_order,
++                                        transport);
++}
++
+ void Curl_ssl_config_cleanup(struct ssl_primary_config *sslc)
+ {
+   if(sslc->deep_copy) {
+@@ -127,7 +159,12 @@ void Curl_ssl_config_cleanup(struct ssl_primary_config *sslc)
      curlx_safefree(sslc->issuercert_blob);
      curlx_safefree(sslc->key_blob);
      curlx_safefree(sslc->curves);
 +    curlx_safefree(sslc->tls_extension_order);
 +    curlx_safefree(sslc->cert_compression);
      curlx_safefree(sslc->signature_algorithms);
++    curlx_safefree(sslc->http3_curves);
++    curlx_safefree(sslc->http3_signature_algorithms);
++    curlx_safefree(sslc->http3_tls_extension_order);
      curlx_safefree(sslc->CRLfile);
      curlx_safefree(sslc->cert_type);
-@@ -152,6 +154,7 @@ static bool match_ssl_primary_config(struct Curl_easy *data,
+     curlx_safefree(sslc->key);
+@@ -152,6 +189,7 @@ static bool match_ssl_primary_config(struct Curl_easy *data,
       (c1->verifypeer == c2->verifypeer) &&
       (c1->verifyhost == c2->verifyhost) &&
       (c1->verifystatus == c2->verifystatus) &&
@@ -9634,16 +9833,22 @@ index 4a9b69654b..d3c73e598a 100644
       blobcmp(c1->cert_blob, c2->cert_blob) &&
       blobcmp(c1->ca_info_blob, c2->ca_info_blob) &&
       blobcmp(c1->issuercert_blob, c2->issuercert_blob) &&
-@@ -167,6 +170,8 @@ static bool match_ssl_primary_config(struct Curl_easy *data,
+@@ -167,7 +205,14 @@ static bool match_ssl_primary_config(struct Curl_easy *data,
       curl_strequal(c1->cipher_list, c2->cipher_list) &&
       curl_strequal(c1->cipher_list13, c2->cipher_list13) &&
       curl_strequal(c1->curves, c2->curves) &&
 +     curl_strequal(c1->tls_extension_order, c2->tls_extension_order) &&
 +     curl_strequal(c1->cert_compression, c2->cert_compression) &&
       curl_strequal(c1->signature_algorithms, c2->signature_algorithms) &&
++     curl_strequal(c1->http3_curves, c2->http3_curves) &&
++     curl_strequal(c1->http3_signature_algorithms,
++                   c2->http3_signature_algorithms) &&
++     curl_strequal(c1->http3_tls_extension_order,
++                   c2->http3_tls_extension_order) &&
       Curl_safecmp(c1->CRLfile, c2->CRLfile) &&
       Curl_safecmp(c1->pinned_key, c2->pinned_key) &&
-@@ -205,6 +210,7 @@ static bool clone_ssl_primary_config(struct ssl_primary_config *source,
+      curl_strequal(c1->cert_type, c2->cert_type) &&
+@@ -205,6 +250,7 @@ static bool clone_ssl_primary_config(struct ssl_primary_config *source,
    dest->verifyhost = source->verifyhost;
    dest->verifystatus = source->verifystatus;
    dest->cache_session = source->cache_session;
@@ -9651,16 +9856,20 @@ index 4a9b69654b..d3c73e598a 100644
    dest->ssl_options = source->ssl_options;
  
    CLONE_BLOB(cert_blob);
-@@ -217,6 +223,8 @@ static bool clone_ssl_primary_config(struct ssl_primary_config *source,
+@@ -217,7 +263,12 @@ static bool clone_ssl_primary_config(struct ssl_primary_config *source,
    CLONE_STRING(cipher_list13);
    CLONE_STRING(pinned_key);
    CLONE_STRING(curves);
 +  CLONE_STRING(tls_extension_order);
 +  CLONE_STRING(cert_compression);
    CLONE_STRING(signature_algorithms);
++  CLONE_STRING(http3_curves);
++  CLONE_STRING(http3_signature_algorithms);
++  CLONE_STRING(http3_tls_extension_order);
    CLONE_STRING(CRLfile);
    /* SSL credentials: client certificate, SRP auth */
-@@ -253,10 +261,14 @@ static void ssl_easy_config_compl_options(struct Curl_peer *origin,
+   CLONE_STRING(clientcert);
+@@ -253,10 +304,13 @@ static void ssl_easy_config_compl_options(struct Curl_peer *origin,
                             !!(options & CURLSSLOPT_AUTO_CLIENT_CERT);
  }
  
@@ -9671,13 +9880,12 @@ index 4a9b69654b..d3c73e598a 100644
 +                                         struct connectdata *conn)
  {
    struct ssl_config_data *sslc = &data->set.ssl;
-+  const bool is_h3 = conn && conn->transport_wanted == TRNSPRT_QUIC;
 +  const bool is_wss = conn && conn->scheme &&
 +    (conn->scheme->protocol & CURLPROTO_WSS);
  #if defined(CURL_CA_PATH) || defined(CURL_CA_BUNDLE)
    struct UserDefined *set = &data->set;
    CURLcode result;
-@@ -293,6 +305,29 @@ CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
+@@ -293,6 +347,24 @@ CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
      data->set.str[STRING_SSL_SIGNATURE_ALGORITHMS];
    sslc->primary.ca_info_blob = data->set.blobs[BLOB_CAINFO];
    sslc->primary.curves = data->set.str[STRING_SSL_EC_CURVES];
@@ -9685,6 +9893,11 @@ index 4a9b69654b..d3c73e598a 100644
 +    data->set.str[STRING_TLS_EXTENSION_ORDER];
 +  sslc->primary.cert_compression =
 +    data->set.str[STRING_SSL_CERT_COMPRESSION];
++  sslc->primary.http3_curves = data->set.str[STRING_HTTP3_SSL_EC_CURVES];
++  sslc->primary.http3_signature_algorithms =
++    data->set.str[STRING_HTTP3_SIG_HASH_ALGS];
++  sslc->primary.http3_tls_extension_order =
++    data->set.str[STRING_HTTP3_TLS_EXTENSION_ORDER];
 +  sslc->primary.enable_ticket = data->set.ssl_enable_ticket;
 +
 +  if(is_wss) {
@@ -9694,20 +9907,10 @@ index 4a9b69654b..d3c73e598a 100644
 +      sslc->primary.cert_compression =
 +        data->set.str[STRING_WS_SSL_CERT_COMPRESSION];
 +  }
-+  else if(is_h3) {
-+    if(data->set.str[STRING_HTTP3_SSL_EC_CURVES])
-+      sslc->primary.curves = data->set.str[STRING_HTTP3_SSL_EC_CURVES];
-+    if(data->set.str[STRING_HTTP3_SIG_HASH_ALGS])
-+      sslc->primary.signature_algorithms =
-+        data->set.str[STRING_HTTP3_SIG_HASH_ALGS];
-+    if(data->set.str[STRING_HTTP3_TLS_EXTENSION_ORDER])
-+      sslc->primary.tls_extension_order =
-+        data->set.str[STRING_HTTP3_TLS_EXTENSION_ORDER];
-+  }
    /* Maybe these should not be used for another origin. But for
     * backwards compatibility, keep them in. */
    sslc->primary.issuercert = data->set.str[STRING_SSL_ISSUERCERT];
-@@ -358,6 +393,7 @@ CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
+@@ -358,6 +430,7 @@ CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
    sslc->primary.CApath = data->set.str[STRING_SSL_CAPATH_PROXY];
    sslc->primary.cipher_list = data->set.str[STRING_SSL_CIPHER_LIST_PROXY];
    sslc->primary.cipher_list13 = data->set.str[STRING_SSL_CIPHER13_LIST_PROXY];
@@ -9715,7 +9918,7 @@ index 4a9b69654b..d3c73e598a 100644
    sslc->primary.pinned_key = data->set.str[STRING_SSL_PINNEDPUBLICKEY_PROXY];
    sslc->primary.cert_blob = data->set.blobs[BLOB_CERT_PROXY];
    sslc->primary.ca_info_blob = data->set.blobs[BLOB_CAINFO_PROXY];
-@@ -379,6 +415,18 @@ CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
+@@ -379,6 +452,18 @@ CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
    return CURLE_OK;
  }
  
@@ -9735,19 +9938,22 @@ index 4a9b69654b..d3c73e598a 100644
                                     struct connectdata *conn)
  {
 diff --git a/lib/vtls/vtls_config.h b/lib/vtls/vtls_config.h
-index 44e691dd26..be680be477 100644
+index 44e691dd26..7e0e5d53bc 100644
 --- a/lib/vtls/vtls_config.h
 +++ b/lib/vtls/vtls_config.h
-@@ -52,6 +52,8 @@ struct ssl_primary_config {
+@@ -52,6 +52,11 @@ struct ssl_primary_config {
    char *password; /* TLS password (for, e.g., SRP) */
  #endif
    char *curves;          /* list of curves to use */
 +  char *tls_extension_order; /* TLS extension order to use */
 +  char *cert_compression; /* certificate compression algorithms */
++  char *http3_curves;    /* HTTP/3 list of curves to use */
++  char *http3_signature_algorithms; /* HTTP/3 signature algorithms */
++  char *http3_tls_extension_order; /* HTTP/3 TLS extension order */
    uint32_t version_max; /* max supported version the client wants to use */
    uint8_t ssl_options;  /* the CURLOPT_SSL_OPTIONS bitmask */
    uint8_t version;    /* what version the client wants to use */
-@@ -59,6 +61,7 @@ struct ssl_primary_config {
+@@ -59,6 +64,7 @@ struct ssl_primary_config {
    BIT(verifyhost);       /* set TRUE if CN/SAN must match hostname */
    BIT(verifystatus);     /* set TRUE if certificate status must be checked */
    BIT(cache_session);    /* cache session or not */
@@ -9755,7 +9961,21 @@ index 44e691dd26..be680be477 100644
    BIT(deep_copy);        /* members are deep copies, eg. owned here */
  };
  
-@@ -96,6 +99,12 @@ void Curl_ssl_config_cleanup(struct ssl_primary_config *sslc);
+@@ -89,6 +95,13 @@ struct ssl_general_config {
+ void Curl_ssl_config_init(struct ssl_primary_config *sslc);
+ void Curl_ssl_config_cleanup(struct ssl_primary_config *sslc);
+ 
++const char *Curl_ssl_config_get_curves(
++  const struct ssl_primary_config *sslc, uint8_t transport);
++const char *Curl_ssl_config_get_signature_algorithms(
++  const struct ssl_primary_config *sslc, uint8_t transport);
++const char *Curl_ssl_config_get_tls_extension_order(
++  const struct ssl_primary_config *sslc, uint8_t transport);
++
+ /**
+  * Init the `data->set.ssl` and `data->set.proxy_ssl` for
+  * connection matching use.
+@@ -96,6 +109,12 @@ void Curl_ssl_config_cleanup(struct ssl_primary_config *sslc);
  CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
                                         struct Curl_peer *origin);
  
@@ -9781,10 +10001,10 @@ index fa5da6e4d5..45aeb422c2 100644
    struct cf_call_data call_data;    /* data handle used in current call */
    struct curltime handshake_done;   /* time when handshake finished */
 diff --git a/lib/vtls/vtls_scache.c b/lib/vtls/vtls_scache.c
-index 98beeac036..187f21dbc6 100644
+index 98beeac036..8f9e4762f9 100644
 --- a/lib/vtls/vtls_scache.c
 +++ b/lib/vtls/vtls_scache.c
-@@ -228,6 +228,7 @@ static CURLcode ssl_peer_key_add_vrfy(struct dynbuf *buf,
+@@ -228,10 +228,16 @@ static CURLcode ssl_peer_key_add_vrfy(struct dynbuf *buf,
  
  static CURLcode ssl_peer_key_build(struct ssl_primary_config *ssl,
                                     const struct ssl_peer *peer,
@@ -9792,7 +10012,16 @@ index 98beeac036..187f21dbc6 100644
                                     const char *tls_id,
                                     char **ppeer_key)
  {
-@@ -260,6 +261,11 @@ static CURLcode ssl_peer_key_build(struct ssl_primary_config *ssl,
+   struct dynbuf buf;
++  const char *curves = Curl_ssl_config_get_curves(ssl, peer->transport);
++  const char *signature_algorithms =
++    Curl_ssl_config_get_signature_algorithms(ssl, peer->transport);
++  const char *tls_extension_order =
++    Curl_ssl_config_get_tls_extension_order(ssl, peer->transport);
+   size_t key_len;
+   bool is_local = FALSE;
+   CURLcode result;
+@@ -260,6 +266,11 @@ static CURLcode ssl_peer_key_build(struct ssl_primary_config *ssl,
      if(result)
        goto out;
    }
@@ -9804,7 +10033,32 @@ index 98beeac036..187f21dbc6 100644
    if(ssl->cipher_list) {
      result = curlx_dyn_addf(&buf, ":CIPHER-%s", ssl->cipher_list);
      if(result)
-@@ -281,6 +287,45 @@ static CURLcode ssl_peer_key_build(struct ssl_primary_config *ssl,
+@@ -270,17 +281,65 @@ static CURLcode ssl_peer_key_build(struct ssl_primary_config *ssl,
+     if(result)
+       goto out;
+   }
+-  if(ssl->curves) {
+-    result = curlx_dyn_addf(&buf, ":CURVES-%s", ssl->curves);
++  if(curves) {
++    result = curlx_dyn_addf(&buf, ":CURVES-%s", curves);
++    if(result)
++      goto out;
++  }
++  if(signature_algorithms) {
++    result = curlx_dyn_addf(&buf, ":SIGALGS-%s", signature_algorithms);
++    if(result)
++      goto out;
++  }
++  if(tls_extension_order) {
++    result = curlx_dyn_addf(&buf, ":EXTORDER-%s", tls_extension_order);
+     if(result)
+       goto out;
+   }
+-  if(ssl->signature_algorithms) {
+-    result = curlx_dyn_addf(&buf, ":SIGALGS-%s",
+-                            ssl->signature_algorithms);
++  if(ssl->cert_compression) {
++    result = curlx_dyn_addf(&buf, ":CERTCOMP-%s", ssl->cert_compression);
      if(result)
        goto out;
    }
@@ -9850,7 +10104,7 @@ index 98beeac036..187f21dbc6 100644
    if(ssl->verifypeer) {
      result = cf_ssl_peer_key_add_path(&buf, "CA", ssl->CAfile, &is_local);
      if(result)
-@@ -356,7 +401,16 @@ CURLcode Curl_ssl_peer_key_make(const struct ssl_peer *peer,
+@@ -356,7 +415,16 @@ CURLcode Curl_ssl_peer_key_make(const struct ssl_peer *peer,
                                  const char *tls_id,
                                  char **ppeer_key)
  {
@@ -9885,6 +10139,33 @@ index effb1d8f96..a0a8e2f596 100644
  /* Return if there is a session cache shall be used.
   * An SSL session might not be configured or not available for
   * "connect-only" transfers.
+diff --git a/lib/vtls/wolfssl.c b/lib/vtls/wolfssl.c
+index 92eaa7a751..44618edc29 100644
+--- a/lib/vtls/wolfssl.c
++++ b/lib/vtls/wolfssl.c
+@@ -1129,9 +1129,11 @@ static CURLcode wssl_init_ciphers(struct Curl_easy *data,
+ 
+ static CURLcode wssl_init_curves(struct Curl_easy *data,
+                                  struct wssl_ctx *wctx,
+-                                 struct ssl_primary_config *conn_config)
++                                 struct ssl_primary_config *conn_config,
++                                 uint8_t transport)
+ {
+-  char *curves = conn_config->curves;
++  char *curves = (char *)CURL_UNCONST(
++    Curl_ssl_config_get_curves(conn_config, transport));
+   /* Without an explicit list, leave the key share group selection to
+      wolfSSL's own default. */
+   if(curves && !wssl_CTX_set1_groups_list(wctx->ssl_ctx, curves)) {
+@@ -1338,7 +1340,7 @@ CURLcode Curl_wssl_ctx_init(struct wssl_ctx *wctx,
+   if(result)
+     goto out;
+ 
+-  result = wssl_init_curves(data, wctx, conn_config);
++  result = wssl_init_curves(data, wctx, conn_config, transport);
+   if(result)
+     goto out;
+ 
 diff --git a/lib/ws.c b/lib/ws.c
 index 9820c3e4bd..fd125d35d4 100644
 --- a/lib/ws.c
@@ -10634,7 +10915,7 @@ index 69554ee490..d0052604bd 100644
  # if unit tests are enabled, build a static library to link them with
  if BUILD_UNITTESTS
 diff --git a/src/config2setopts.c b/src/config2setopts.c
-index 8933668a2c..98b8a70847 100644
+index 8933668a2c..2d6591062c 100644
 --- a/src/config2setopts.c
 +++ b/src/config2setopts.c
 @@ -383,6 +383,9 @@ static CURLcode ssl_setopts(struct OperationConfig *config, CURL *curl)
@@ -10726,7 +11007,7 @@ index 8933668a2c..98b8a70847 100644
  
    return result;
  }
-@@ -604,6 +659,79 @@ static CURLcode http_setopts(struct OperationConfig *config, CURL *curl,
+@@ -604,6 +659,84 @@ static CURLcode http_setopts(struct OperationConfig *config, CURL *curl,
    if(config->hsts)
      MY_SETOPT_STR(curl, CURLOPT_HSTS, config->hsts);
  
@@ -10797,6 +11078,11 @@ index 8933668a2c..98b8a70847 100644
 +                  CURLOPT_HTTP3_TLS_EXTENSION_ORDER,
 +                  config->http3_tls_extension_order);
 +
++  if(config->quic_cid_length)
++    my_setopt_str(curl,
++                  CURLOPT_QUIC_CID_LENGTH,
++                  config->quic_cid_length);
++
 +  if(config->quic_transport_parameters)
 +    my_setopt_str(curl,
 +                  CURLOPT_QUIC_TRANSPORT_PARAMETERS,
@@ -10806,7 +11092,7 @@ index 8933668a2c..98b8a70847 100644
    if(config->expect100timeout_ms > 0)
      my_setopt_long(curl, CURLOPT_EXPECT_100_TIMEOUT_MS,
                     config->expect100timeout_ms);
-@@ -773,6 +901,10 @@ static CURLcode proxy_setopts(struct OperationConfig *config, CURL *curl)
+@@ -773,6 +906,10 @@ static CURLcode proxy_setopts(struct OperationConfig *config, CURL *curl)
    if(config->haproxy_clientip)
      MY_SETOPT_STR(curl, CURLOPT_HAPROXY_CLIENT_IP, config->haproxy_clientip);
  
@@ -10817,7 +11103,7 @@ index 8933668a2c..98b8a70847 100644
    return result;
  }
  
-@@ -926,11 +1058,13 @@ CURLcode config2setopts(struct OperationConfig *config,
+@@ -926,11 +1063,13 @@ CURLcode config2setopts(struct OperationConfig *config,
      my_setopt_bitmask(curl, CURLOPT_HTTPAUTH, config->authtype);
  
    my_setopt_slist(curl, CURLOPT_HTTPHEADER, config->headers);
@@ -10833,7 +11119,7 @@ index 8933668a2c..98b8a70847 100644
    }
  
    result = http_setopts(config, curl, use_proto);
-@@ -939,6 +1073,13 @@ CURLcode config2setopts(struct OperationConfig *config,
+@@ -939,6 +1078,13 @@ CURLcode config2setopts(struct OperationConfig *config,
    if(result)
      return result;
  
@@ -10848,10 +11134,10 @@ index 8933668a2c..98b8a70847 100644
    my_setopt_long(curl, CURLOPT_LOW_SPEED_TIME, config->low_speed_time);
    my_setopt_offt(curl, CURLOPT_MAX_SEND_SPEED_LARGE, config->sendpersecond);
 diff --git a/src/tool_cfgable.c b/src/tool_cfgable.c
-index 3feb3e7824..41722dcb4a 100644
+index 3feb3e7824..a58641fc43 100644
 --- a/src/tool_cfgable.c
 +++ b/src/tool_cfgable.c
-@@ -106,6 +106,25 @@ static void free_config_fields(struct OperationConfig *config)
+@@ -106,6 +106,26 @@ static void free_config_fields(struct OperationConfig *config)
    curlx_safefree(config->proto_str);
    curlx_safefree(config->proto_redir_str);
  
@@ -10869,6 +11155,7 @@ index 3feb3e7824..41722dcb4a 100644
 +  curlx_safefree(config->http3_ssl_ec_curves);
 +  curlx_safefree(config->http3_sig_hash_algs);
 +  curlx_safefree(config->http3_tls_extension_order);
++  curlx_safefree(config->quic_cid_length);
 +  curlx_safefree(config->quic_transport_parameters);
 +  curlx_safefree(config->ws_http_header_order);
 +  curlx_safefree(config->tls_extension_order);
@@ -10877,7 +11164,7 @@ index 3feb3e7824..41722dcb4a 100644
    urlnode = config->url_list;
    while(urlnode) {
      struct getout *next = urlnode->next;
-@@ -154,7 +173,7 @@ static void free_config_fields(struct OperationConfig *config)
+@@ -154,7 +174,7 @@ static void free_config_fields(struct OperationConfig *config)
    curlx_safefree(config->etag_save_file);
    curlx_safefree(config->etag_compare_file);
    curlx_safefree(config->ssl_ec_curves);
@@ -10886,7 +11173,7 @@ index 3feb3e7824..41722dcb4a 100644
    curlx_safefree(config->request_target);
    curlx_safefree(config->customrequest);
    curlx_safefree(config->krblevel);
-@@ -169,6 +188,8 @@ static void free_config_fields(struct OperationConfig *config)
+@@ -169,6 +189,8 @@ static void free_config_fields(struct OperationConfig *config)
    curl_slist_free_all(config->prequote);
  
    curl_slist_free_all(config->headers);
@@ -10896,7 +11183,7 @@ index 3feb3e7824..41722dcb4a 100644
  
    curl_mime_free(config->mimepost);
 diff --git a/src/tool_cfgable.h b/src/tool_cfgable.h
-index 0f8bc6fe08..d961a8943d 100644
+index 0f8bc6fe08..124acbe6c5 100644
 --- a/src/tool_cfgable.h
 +++ b/src/tool_cfgable.h
 @@ -124,6 +124,7 @@ struct OperationConfig {
@@ -10907,7 +11194,7 @@ index 0f8bc6fe08..d961a8943d 100644
    char *pubkey;
    char *hostpubmd5;
    char *hostpubsha256;
-@@ -132,15 +133,45 @@ struct OperationConfig {
+@@ -132,15 +133,46 @@ struct OperationConfig {
    char *etag_compare_file;
    char *customrequest;
    char *ssl_ec_curves;
@@ -10930,6 +11217,7 @@ index 0f8bc6fe08..d961a8943d 100644
 +  char *http3_ssl_ec_curves;
 +  char *http3_sig_hash_algs;
 +  char *http3_tls_extension_order;
++  char *quic_cid_length;
 +  char *quic_transport_parameters;
 +  char *ws_http_header_order;
 +  bool ws_disable_session_ticket;
@@ -10953,7 +11241,7 @@ index 0f8bc6fe08..d961a8943d 100644
    struct curl_slist *proxyheaders;
    struct tool_mime *mimeroot;
    struct tool_mime *mimecurrent;
-@@ -194,6 +225,9 @@ struct OperationConfig {
+@@ -194,6 +226,9 @@ struct OperationConfig {
    long alivetime;           /* keepalive-time */
    long alivecnt;            /* keepalive-cnt */
    long gssapi_delegation;
@@ -10963,7 +11251,7 @@ index 0f8bc6fe08..d961a8943d 100644
    long expect100timeout_ms;
    long happy_eyeballs_timeout_ms; /* happy eyeballs timeout in milliseconds.
                                       0 is valid. default: CURL_HET_DEFAULT. */
-@@ -220,6 +254,7 @@ struct OperationConfig {
+@@ -220,6 +255,7 @@ struct OperationConfig {
    BIT(remote_name_all);   /* --remote-name-all */
    BIT(remote_time);
    BIT(cookiesession);       /* new session? */
@@ -10972,7 +11260,7 @@ index 0f8bc6fe08..d961a8943d 100644
    BIT(tr_encoding);         /* Transfer-Encoding please */
    BIT(use_resume);
 diff --git a/src/tool_getparam.c b/src/tool_getparam.c
-index 35c01b1d92..1cf592678c 100644
+index 35c01b1d92..ad260daeff 100644
 --- a/src/tool_getparam.c
 +++ b/src/tool_getparam.c
 @@ -76,6 +76,7 @@ static ParameterError getstrn(char **str, const char *val,
@@ -11046,15 +11334,16 @@ index 35c01b1d92..1cf592678c 100644
    {"proxy-crlfile",              ARG_FILE|ARG_TLS, ' ', C_PROXY_CRLFILE},
    {"proxy-digest",               ARG_BOOL, ' ', C_PROXY_DIGEST},
    {"proxy-header",               ARG_STRG, ' ', C_PROXY_HEADER},
-@@ -272,6 +293,7 @@ static const struct LongShort aliases[]= {
+@@ -272,6 +293,8 @@ static const struct LongShort aliases[]= {
    {"proxy1.0",                   ARG_STRG, ' ', C_PROXY1_0},
    {"proxytunnel",                ARG_BOOL, 'p', C_PROXYTUNNEL},
    {"pubkey",                     ARG_STRG, ' ', C_PUBKEY},
++  {"quic-cid-length",            ARG_STRG|ARG_TLS, ' ', C_QUIC_CID_LENGTH},  // curl-impersonate
 +  {"quic-transport-params",      ARG_STRG|ARG_TLS, ' ', C_QUIC_TRANSPORT_PARAMETERS},  // curl-impersonate
    {"quote",                      ARG_STRG, 'Q', C_QUOTE},
    {"random-file",                ARG_FILE|ARG_DEPR, ' ', C_RANDOM_FILE},
    {"range",                      ARG_STRG, 'r', C_RANGE},
-@@ -297,8 +319,8 @@ static const struct LongShort aliases[]= {
+@@ -297,8 +320,8 @@ static const struct LongShort aliases[]= {
    {"sessionid",                  ARG_BOOL|ARG_NO, ' ', C_SESSIONID},
    {"show-error",                 ARG_BOOL, 'S', C_SHOW_ERROR},
    {"show-headers",               ARG_BOOL, 'i', C_SHOW_HEADERS},
@@ -11065,7 +11354,7 @@ index 35c01b1d92..1cf592678c 100644
    {"silent",                     ARG_BOOL, 's', C_SILENT},
    {"skip-existing",              ARG_BOOL, ' ', C_SKIP_EXISTING},
    {"socks4",                     ARG_STRG, ' ', C_SOCKS4},
-@@ -311,6 +333,7 @@ static const struct LongShort aliases[]= {
+@@ -311,6 +334,7 @@ static const struct LongShort aliases[]= {
    {"socks5-hostname",            ARG_STRG, ' ', C_SOCKS5_HOSTNAME},
    {"speed-limit",                ARG_UNUM, 'Y', C_SPEED_LIMIT},
    {"speed-time",                 ARG_UNUM, 'y', C_SPEED_TIME},
@@ -11073,7 +11362,7 @@ index 35c01b1d92..1cf592678c 100644
    {"ssl",                        ARG_BOOL|ARG_TLS, ' ', C_SSL},
    {"ssl-allow-beast",            ARG_BOOL|ARG_TLS, ' ', C_SSL_ALLOW_BEAST},
    {"ssl-auto-client-cert",       ARG_BOOL|ARG_TLS, ' ',
-@@ -335,8 +358,17 @@ static const struct LongShort aliases[]= {
+@@ -335,8 +359,17 @@ static const struct LongShort aliases[]= {
    {"tftp-blksize",               ARG_UNUM, ' ', C_TFTP_BLKSIZE},
    {"tftp-no-options",            ARG_BOOL, ' ', C_TFTP_NO_OPTIONS},
    {"time-cond",                  ARG_STRG, 'z', C_TIME_COND},
@@ -11091,18 +11380,18 @@ index 35c01b1d92..1cf592678c 100644
    {"tls13-ciphers",              ARG_STRG|ARG_TLS, ' ', C_TLS13_CIPHERS},
    {"tlsauthtype",                ARG_STRG|ARG_TLS, ' ', C_TLSAUTHTYPE},
    {"tlspassword",              ARG_STRG|ARG_TLS|ARG_CLEAR, ' ', C_TLSPASSWORD},
-@@ -367,6 +399,10 @@ static const struct LongShort aliases[]= {
- #ifdef USE_WATT32
+@@ -368,6 +401,10 @@ static const struct LongShort aliases[]= {
    {"wdebug",                     ARG_BOOL, ' ', C_WDEBUG},
  #endif
+   {"write-out",                  ARG_STRG, 'w', C_WRITE_OUT},
 +  {"ws-cert-compression",        ARG_STRG|ARG_TLS, ' ', C_WS_CERT_COMPRESSION},  // curl-impersonate
 +  {"ws-disable-session-ticket",  ARG_BOOL, ' ', C_WS_DISABLE_SESSION_TICKET},  // curl-impersonate
 +  {"ws-httpheader",              ARG_STRG, ' ', C_WS_HTTPHEADER},  // curl-impersonate
 +  {"ws-httpheader-order",        ARG_STRG, ' ', C_WS_HTTPHEADER_ORDER},  // curl-impersonate
-   {"write-out",                  ARG_STRG, 'w', C_WRITE_OUT},
    {"xattr",                      ARG_BOOL, ' ', C_XATTR},
  };
-@@ -1305,9 +1341,14 @@ static ParameterError parse_header(struct OperationConfig *config,
+ 
+@@ -1305,9 +1342,14 @@ static ParameterError parse_header(struct OperationConfig *config,
        curlx_dyn_init(&line, 1024 * 100);
        while(my_get_line(file, &line, &error)) {
          const char *ptr = curlx_dyn_ptr(&line);
@@ -11120,7 +11409,7 @@ index 35c01b1d92..1cf592678c 100644
          if(err)
            break;
        }
-@@ -1325,6 +1366,10 @@ static ParameterError parse_header(struct OperationConfig *config,
+@@ -1325,6 +1367,10 @@ static ParameterError parse_header(struct OperationConfig *config,
      }
      if(cmd == C_PROXY_HEADER) /* --proxy-header */
        err = add2list(&config->proxyheaders, nextarg);
@@ -11131,7 +11420,7 @@ index 35c01b1d92..1cf592678c 100644
      else
        err = add2list(&config->headers, nextarg);
    }
-@@ -1834,6 +1879,9 @@ static ParameterError opt_bool(struct OperationConfig *config,
+@@ -1834,6 +1880,9 @@ static ParameterError opt_bool(struct OperationConfig *config,
    case C_ALPN: /* --alpn */
      config->noalpn = !toggle;
      break;
@@ -11141,7 +11430,7 @@ index 35c01b1d92..1cf592678c 100644
    case C_DISABLE_EPSV: /* --disable-epsv */
      config->disable_epsv = toggle;
      break;
-@@ -2009,6 +2057,29 @@ static ParameterError opt_bool(struct OperationConfig *config,
+@@ -2009,6 +2058,29 @@ static ParameterError opt_bool(struct OperationConfig *config,
    case C_TLS_EARLYDATA: /* --tls-earlydata */
      config->ssl_allow_earlydata = toggle;
      break;
@@ -11171,7 +11460,7 @@ index 35c01b1d92..1cf592678c 100644
    case C_SUPPRESS_CONNECT_HEADERS: /* --suppress-connect-headers */
      config->suppress_connect_headers = toggle;
      break;
-@@ -2135,6 +2206,9 @@ static ParameterError opt_bool(struct OperationConfig *config,
+@@ -2135,6 +2207,9 @@ static ParameterError opt_bool(struct OperationConfig *config,
    case C_JUNK_SESSION_COOKIES: /* --junk-session-cookies */
      config->cookiesession = toggle;
      break;
@@ -11181,7 +11470,7 @@ index 35c01b1d92..1cf592678c 100644
    case C_HEAD: /* --head */
      config->no_body = toggle;
      config->show_headers = toggle;
-@@ -2154,6 +2228,9 @@ static ParameterError opt_bool(struct OperationConfig *config,
+@@ -2154,6 +2229,9 @@ static ParameterError opt_bool(struct OperationConfig *config,
    case C_LIST_ONLY: /* --list-only */
      config->dirlistonly = toggle; /* only list names of the FTP directory */
      break;
@@ -11191,7 +11480,7 @@ index 35c01b1d92..1cf592678c 100644
    case C_MANUAL: /* --manual */
      if(toggle)   /* --no-manual shows no manual... */
        return PARAM_MANUAL_REQUESTED;
-@@ -2213,6 +2290,9 @@ static ParameterError opt_bool(struct OperationConfig *config,
+@@ -2213,6 +2291,9 @@ static ParameterError opt_bool(struct OperationConfig *config,
    case C_MPTCP: /* --mptcp */
      config->mptcp = toggle;
      break;
@@ -11201,7 +11490,7 @@ index 35c01b1d92..1cf592678c 100644
    case C_LOCATION_TRUSTED: /* --location-trusted */
      config->unrestricted_auth = toggle;
      FALLTHROUGH();
-@@ -2680,6 +2760,104 @@ static ParameterError opt_string(struct OperationConfig *config,
+@@ -2680,6 +2761,109 @@ static ParameterError opt_string(struct OperationConfig *config,
        err = PARAM_BAD_USE;
      }
      break;
@@ -11286,6 +11575,11 @@ index 35c01b1d92..1cf592678c 100644
 +  case C_WS_HTTPHEADER_ORDER:  /* --ws-httpheader-order curl-impersonate */
 +    err = getstr(&config->ws_http_header_order, nextarg, ALLOW_BLANK);
 +    break;
++  case C_QUIC_CID_LENGTH:  /* --quic-cid-length curl-impersonate */
++    if(!feature_http3)
++      return PARAM_LIBCURL_DOESNT_SUPPORT;
++    err = getstr(&config->quic_cid_length, nextarg, DENY_BLANK);
++    break;
 +  case C_QUIC_TRANSPORT_PARAMETERS:  /* --quic-transport-params curl-impersonate */
 +    if(!feature_http3)
 +      return PARAM_LIBCURL_DOESNT_SUPPORT;
@@ -11306,7 +11600,7 @@ index 35c01b1d92..1cf592678c 100644
    case C_TRACE_CONFIG: /* --trace-config */
      global->trace_set = TRUE;
      if(set_trace_config(nextarg))
-@@ -2709,6 +2887,9 @@ static ParameterError opt_string(struct OperationConfig *config,
+@@ -2709,6 +2893,9 @@ static ParameterError opt_string(struct OperationConfig *config,
      else
        err = getstr(&config->hsts, nextarg, ALLOW_BLANK);
      break;
@@ -11316,7 +11610,7 @@ index 35c01b1d92..1cf592678c 100644
    case C_COOKIE: /* --cookie */
      if(strchr(nextarg, '=')) {
        /* A cookie string must have a =-letter */
-@@ -2870,8 +3051,14 @@ static ParameterError opt_string(struct OperationConfig *config,
+@@ -2870,8 +3057,14 @@ static ParameterError opt_string(struct OperationConfig *config,
    case C_REQUEST_TARGET: /* --request-target */
      err = getstr(&config->request_target, nextarg, DENY_BLANK);
      break;
@@ -11332,7 +11626,7 @@ index 35c01b1d92..1cf592678c 100644
      break;
    case C_OUTPUT_DIR: /* --output-dir */
 diff --git a/src/tool_getparam.h b/src/tool_getparam.h
-index 32476d3776..01084730d2 100644
+index 32476d3776..a1053e873b 100644
 --- a/src/tool_getparam.h
 +++ b/src/tool_getparam.h
 @@ -31,6 +31,7 @@
@@ -11406,15 +11700,16 @@ index 32476d3776..01084730d2 100644
    C_PROXY_CRLFILE,
    C_PROXY_DIGEST,
    C_PROXY_HEADER,
-@@ -221,6 +242,7 @@ typedef enum {
+@@ -221,6 +242,8 @@ typedef enum {
    C_PROXY1_0,
    C_PROXYTUNNEL,
    C_PUBKEY,
++  C_QUIC_CID_LENGTH,
 +  C_QUIC_TRANSPORT_PARAMETERS,
    C_QUOTE,
    C_RANDOM_FILE,
    C_RANGE,
-@@ -246,6 +268,7 @@ typedef enum {
+@@ -246,6 +269,7 @@ typedef enum {
    C_SESSIONID,
    C_SHOW_ERROR,
    C_SHOW_HEADERS,
@@ -11422,7 +11717,7 @@ index 32476d3776..01084730d2 100644
    C_SILENT,
    C_SIGNATURE_ALGORITHMS,
    C_SKIP_EXISTING,
-@@ -259,6 +282,7 @@ typedef enum {
+@@ -259,6 +283,7 @@ typedef enum {
    C_SOCKS5_HOSTNAME,
    C_SPEED_LIMIT,
    C_SPEED_TIME,
@@ -11430,7 +11725,7 @@ index 32476d3776..01084730d2 100644
    C_SSL,
    C_SSL_ALLOW_BEAST,
    C_SSL_AUTO_CLIENT_CERT,
-@@ -280,7 +304,16 @@ typedef enum {
+@@ -280,7 +305,16 @@ typedef enum {
    C_TFTP_NO_OPTIONS,
    C_TIME_COND,
    C_TLS_EARLYDATA,
@@ -11447,7 +11742,7 @@ index 32476d3776..01084730d2 100644
    C_TLS13_CIPHERS,
    C_TLSAUTHTYPE,
    C_TLSPASSWORD,
-@@ -310,6 +343,10 @@ typedef enum {
+@@ -310,6 +344,10 @@ typedef enum {
    C_VERSION,
    C_VLAN_PRIORITY,
    C_WDEBUG,
@@ -11459,7 +11754,7 @@ index 32476d3776..01084730d2 100644
    C_XATTR
  } cmdline_t;
 diff --git a/src/tool_listhelp.c b/src/tool_listhelp.c
-index c0b0af792f..48940e1b8b 100644
+index c0b0af792f..2322b67567 100644
 --- a/src/tool_listhelp.c
 +++ b/src/tool_listhelp.c
 @@ -67,6 +67,9 @@ const struct helptxt helptext[] = {
@@ -11567,17 +11862,20 @@ index c0b0af792f..48940e1b8b 100644
    { "    --proxy-crlfile <file>",
      "Set a CRL list for proxy",
      CURLHELP_PROXY | CURLHELP_TLS },
-@@ -660,6 +711,9 @@ const struct helptxt helptext[] = {
-   { "    --retry-max-time <seconds>",
-     "Retry only within this period",
-     CURLHELP_CURL | CURLHELP_TIMEOUT },
+@@ -602,6 +653,12 @@ const struct helptxt helptext[] = {
+   { "    --pubkey <key>",
+     "SSH Public key filename",
+     CURLHELP_SFTP | CURLHELP_SCP | CURLHELP_SSH | CURLHELP_AUTH },
++  { "    --quic-cid-length <profile>",
++    "Set QUIC connection ID length profile",
++    CURLHELP_HTTP },
 +  { "    --quic-transport-params <list>",
 +    "Set QUIC transport parameters",
 +    CURLHELP_HTTP },
-   { "    --sasl-authzid <identity>",
-     "Identity for SASL PLAIN authentication",
-     CURLHELP_AUTH },
-@@ -678,12 +732,18 @@ const struct helptxt helptext[] = {
+   { "-Q, --quote <command>",
+     "Send command(s) to server before transfer",
+     CURLHELP_FTP | CURLHELP_SFTP },
+@@ -678,12 +735,18 @@ const struct helptxt helptext[] = {
    { "    --sigalgs <list>",
      "TLS signature algorithms to use",
      CURLHELP_TLS },
@@ -11596,7 +11894,7 @@ index c0b0af792f..48940e1b8b 100644
    { "    --socks4 <host[:port]>",
      "SOCKS4 proxy on given host + port",
      CURLHELP_PROXY },
-@@ -776,6 +836,9 @@ const struct helptxt helptext[] = {
+@@ -776,6 +839,9 @@ const struct helptxt helptext[] = {
    { "    --tls-max <VERSION>",
      "Maximum allowed TLS version",
      CURLHELP_TLS },
@@ -11606,7 +11904,7 @@ index c0b0af792f..48940e1b8b 100644
    { "    --tls13-ciphers <list>",
      "TLS 1.3 cipher suites to use",
      CURLHELP_TLS },
-@@ -860,6 +923,18 @@ const struct helptxt helptext[] = {
+@@ -860,6 +926,18 @@ const struct helptxt helptext[] = {
    { "-w, --write-out <format>",
      "Output FORMAT after completion",
      CURLHELP_VERBOSE },

--- a/tests/signatures/chrome_150.0.7871.127_macOS.yaml
+++ b/tests/signatures/chrome_150.0.7871.127_macOS.yaml
@@ -1,0 +1,145 @@
+browser:
+  name: chrome
+  os: macOS
+  version: 150.0.7871.127
+signature:
+  options:
+    tls_permute_extensions: true
+  http2:
+    frames:
+    - frame_type: SETTINGS
+      settings:
+      - key: 1
+        value: 65536
+      - key: 2
+        value: 0
+      - key: 4
+        value: 6291456
+      - key: 6
+        value: 262144
+      stream_id: 0
+    - frame_type: WINDOW_UPDATE
+      stream_id: 0
+      window_size_increment: 15663105
+    - frame_type: HEADERS
+      headers:
+      - 'sec-ch-ua: "Not;A=Brand";v="8", "Chromium";v="150", "Google Chrome";v="150"'
+      - 'sec-ch-ua-mobile: ?0'
+      - 'sec-ch-ua-platform: "macOS"'
+      - 'upgrade-insecure-requests: 1'
+      - 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36'
+      - 'accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7'
+      - 'sec-fetch-site: none'
+      - 'sec-fetch-mode: navigate'
+      - 'sec-fetch-user: ?1'
+      - 'sec-fetch-dest: document'
+      - 'accept-encoding: gzip, deflate, br, zstd'
+      - 'accept-language: en-US,en;q=0.9'
+      - 'priority: u=0, i'
+      pseudo_headers:
+      - :method
+      - :authority
+      - :scheme
+      - :path
+      stream_id: 1
+  tls_client_hello:
+    ciphersuites:
+    - GREASE
+    - 4865
+    - 4866
+    - 4867
+    - 49195
+    - 49199
+    - 49196
+    - 49200
+    - 52393
+    - 52392
+    - 49171
+    - 49172
+    - 156
+    - 157
+    - 47
+    - 53
+    comp_methods:
+    - 0
+    extensions:
+    - length: 0
+      type: GREASE
+    - alps_alpn_list:
+      - h2
+      length: 5
+      type: application_settings_new
+    - length: 2
+      psk_ke_mode: 1
+      type: psk_key_exchange_modes
+    - algorithms:
+      - 2
+      length: 3
+      type: compress_certificate
+    - key_shares:
+      - group: GREASE
+        length: 1
+      - group: 4588
+        length: 1216
+      - group: 29
+        length: 32
+      length: 1263
+      type: keyshare
+    - length: 7
+      supported_versions:
+      - GREASE
+      - TLS_VERSION_1_3
+      - TLS_VERSION_1_2
+      type: supported_versions
+    - length: 1
+      type: renegotiation_info
+    - length: 0
+      type: encrypted_client_hello
+    - length: 0
+      type: extended_master_secret
+    - ec_point_formats:
+      - 0
+      length: 2
+      type: ec_point_formats
+    - length: 5
+      status_request_type: 1
+      type: status_request
+    - length: 0
+      type: session_ticket
+    - length: 12
+      supported_groups:
+      - GREASE
+      - 4588
+      - 29
+      - 23
+      - 24
+      type: supported_groups
+    - length: 0
+      type: signed_certificate_timestamp
+    - alpn_list:
+      - h2
+      - http/1.1
+      length: 14
+      type: application_layer_protocol_negotiation
+    - length: 24
+      sig_hash_algs:
+      - 2308
+      - 2309
+      - 2310
+      - 1027
+      - 2052
+      - 1025
+      - 1283
+      - 2053
+      - 1281
+      - 2054
+      - 1537
+      type: signature_algorithms
+    - type: server_name
+    - data: !!binary |
+        AA==
+      length: 1
+      type: GREASE
+    handshake_version: TLS_VERSION_1_2
+    record_version: TLS_VERSION_1_0
+    session_id_length: 32

--- a/tests/targets.yaml
+++ b/tests/targets.yaml
@@ -59,6 +59,10 @@
   - null
   - null
   - chrome_142.0.7444.176_macOS
+- - curl_chrome150
+  - null
+  - null
+  - chrome_150.0.7871.127_macOS
 - - curl_chrome131_android
   - null
   - null


### PR DESCRIPTION
Same profile as chrome146, only signature_algorithms differs: Chrome 150 prepends the ML-DSA algs 2308-2309-2310 (mldsa44/65/87), now parseable since a2e9afb.

Captured from real Chrome 150 (150.0.7871.127), JA4 `t13d1516h2_8daaf6152771_806a8c22fdea`. Local build + `chrome150` signature/H2 tests pass.