### PR TITLE
Overhaul tests: local TLS capture, native aarch64/macOS CI runs

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -22,19 +22,23 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
+      # Fork PRs have no secrets: skip login, use a placeholder repo
       - name: Log in to DockerHub
-        uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Check if tag is present
         id: check_tag
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         run: |
           if [[ "${GITHUB_REF}" =~ ^refs/tags/v ]]; then
             echo "push_image=true" >> $GITHUB_ENV
@@ -43,23 +47,24 @@ jobs:
             echo "push_image=false" >> $GITHUB_ENV
             echo "image_tag=latest" >> $GITHUB_ENV
           fi
+          echo "image_repo=${DOCKER_USERNAME:-local}/curl-impersonate" >> $GITHUB_ENV
 
       - name: Build debian docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/debian.dockerfile
           push: ${{ env.push_image }}
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/curl-impersonate:${{ env.image_tag }}
-            ${{ secrets.DOCKER_USERNAME }}/curl-impersonate:latest
+            ${{ env.image_repo }}:${{ env.image_tag }}
+            ${{ env.image_repo }}:latest
 
       - name: Build alpine docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/alpine.dockerfile
           push: ${{ env.push_image }}
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/curl-impersonate:${{ env.image_tag }}-alpine
-            ${{ secrets.DOCKER_USERNAME }}/curl-impersonate:alpine
+            ${{ env.image_repo }}:${{ env.image_tag }}-alpine
+            ${{ env.image_repo }}:alpine

--- a/.github/workflows/build-win.yaml
+++ b/.github/workflows/build-win.yaml
@@ -27,19 +27,19 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: configure Pagefile
-        uses: al-cheb/configure-pagefile-action@v1.3
+        uses: al-cheb/configure-pagefile-action@v1.5
         with:
           minimum-size: 16GB
           maximum-size: 16GB
           disk-root: "C:"
 
       - name: Install python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Install NASM
         shell: cmd
@@ -77,7 +77,7 @@ jobs:
           tar -czf "$lib_tar"  -C packages lib include
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts.windows.${{ matrix.env }}
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,11 +134,11 @@ jobs:
             make: gmake
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Set up zig
         if: matrix.platform == 'linux'
-        uses: goto-bus-stop/setup-zig@v2
+        uses: mlugg/setup-zig@v2
         with:
           version: 0.14.0
 
@@ -350,7 +350,7 @@ jobs:
           cp ${{ runner.temp }}/install/lib/libcurl-impersonate.a "$slice_dir/lib/"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts.${{ matrix.host_label }}
           path: |
@@ -359,7 +359,7 @@ jobs:
 
       - name: Upload iOS slice artifact
         if: matrix.platform == 'ios'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-slice.${{ matrix.host_label }}
           path: ${{ runner.temp }}/ios-slice
@@ -384,7 +384,7 @@ jobs:
 
       - name: Check out the repo
         if: ${{ !matrix.release_only || startsWith(github.ref, 'refs/tags/') }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Build in FreeBSD
         if: ${{ !matrix.release_only || startsWith(github.ref, 'refs/tags/') }}
@@ -462,7 +462,7 @@ jobs:
 
       - name: Upload FreeBSD artifacts
         if: ${{ !matrix.release_only || startsWith(github.ref, 'refs/tags/') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts.${{ matrix.host_label }}
           path: freebsd-artifacts/*.tar.gz
@@ -473,19 +473,19 @@ jobs:
     needs: build
     steps:
       - name: Download device slice
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ios-slice.arm64-apple-ios
           path: ${{ runner.temp }}/ios/device
 
       - name: Download simulator slice
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ios-slice.arm64-apple-ios-simulator
           path: ${{ runner.temp }}/ios/simulator-arm64
 
       - name: Download Intel simulator slice
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ios-slice.x86_64-apple-ios-simulator
           path: ${{ runner.temp }}/ios/simulator-x86_64
@@ -516,7 +516,7 @@ jobs:
           fi
 
       - name: Upload XCFramework artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts.ios-xcframework
           path: ${{ runner.temp }}/libcurl-impersonate*.ios-xcframework.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - build-windows
     steps:
       - name: Download release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts.*
           path: ${{ runner.temp }}/release-assets

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,21 +17,33 @@ permissions:
 
 jobs:
   test-linux:
-    name: (x86_64-linux-gnu) Build and run tests
-    runs-on: ubuntu-latest
+    name: (${{ matrix.host }}) Build and run tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+            host: x86_64-linux-gnu
+            zig_target: x86_64-linux-gnu.2.17
+          - os: ubuntu-24.04-arm
+            arch: aarch64
+            host: aarch64-linux-gnu
+            zig_target: aarch64-linux-gnu.2.17
     env:
       CC: ${{ github.workspace }}/zigshim/cc
       CXX: ${{ github.workspace }}/zigshim/cxx
       AR: ${{ github.workspace }}/zigshim/ar
-      ZIG_FLAGS: -target x86_64-linux-gnu.2.17
+      ZIG_FLAGS: -target ${{ matrix.zig_target }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Set up zig
-        uses: goto-bus-stop/setup-zig@v2
+        uses: mlugg/setup-zig@v2
         with:
           version: 0.14.0
 
@@ -51,7 +63,7 @@ jobs:
           install_dir="${{ runner.temp }}/install"
           mkdir -p "$install_dir"
           cmake_args="-DCMAKE_INSTALL_PREFIX=$install_dir"
-          cmake_args="$cmake_args -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=x86_64"
+          cmake_args="$cmake_args -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }}"
           cmake_args="$cmake_args -DCURL_CA_PATH=/etc/ssl/certs -DCURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"
           make prepare-libidn2 BUILD_DIR=build
           make configure BUILD_DIR=build CMAKE_CONFIGURE_ARGS="$cmake_args"
@@ -59,7 +71,7 @@ jobs:
           make checkbuild BUILD_DIR=build CMAKE_CONFIGURE_ARGS="$cmake_args"
           make install BUILD_DIR=build CMAKE_CONFIGURE_ARGS="$cmake_args"
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.10'
 
@@ -77,4 +89,45 @@ jobs:
           cd tests
           # sudo is needed for capturing packets
           python_bin=$(which python3)
-          sudo $python_bin -m pytest . --log-cli-level DEBUG --install-dir ${{ runner.temp }}/install --capture-interface eth0
+          sudo $python_bin -m pytest . --log-cli-level DEBUG --install-dir ${{ runner.temp }}/install
+
+  test-macos:
+    name: (arm64-macos) Build and run tests
+    runs-on: macos-14
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install macOS dependencies
+        run: |
+          brew install pkg-config make cmake ninja autoconf automake libtool gpatch gperf
+          which go || brew install go
+          brew install tcpdump nghttp2
+
+      - name: Build curl-impersonate
+        run: |
+          set -e
+          install_dir="${{ runner.temp }}/install"
+          mkdir -p "$install_dir"
+          cmake_args="-G Ninja -DCMAKE_INSTALL_PREFIX=$install_dir"
+          gmake configure BUILD_DIR=build CMAKE_CONFIGURE_ARGS="$cmake_args"
+          gmake build BUILD_DIR=build CMAKE_CONFIGURE_ARGS="$cmake_args"
+          gmake checkbuild BUILD_DIR=build CMAKE_CONFIGURE_ARGS="$cmake_args"
+          gmake install BUILD_DIR=build CMAKE_CONFIGURE_ARGS="$cmake_args"
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies for the tests script
+        run: |
+          pip3 install -r tests/requirements.txt
+
+      - name: Run the tests
+        run: |
+          cd tests
+          # sudo is needed for capturing packets
+          python_bin=$(which python3)
+          sudo $python_bin -m pytest . --log-cli-level DEBUG --install-dir ${{ runner.temp }}/install

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,9 +16,9 @@ This simply runs `pytest` in the container. You can pass additional flags to `py
 
 ## How the tests work
 For each supported browser, the following tests are performed:
-* A packet capture is started while `curl-impersonate` is run with the relevant wrapper script. The Client Hello message is extracted from the capture and compared against the known signature of the browser.
-* `curl-impersonate` is run, connecting to a local `nghttpd` server (a simple HTTP/2 server). The HTTP/2 pseudo-headers and headers are extracted from the output log of `nghttpd` and compared to the known headers of the browser.
-* HTTP/3-enabled profiles connect to `https://fp.impersonate.pro/api/http3` with both the wrapper and the `CURL_IMPERSONATE`/`LD_PRELOAD` libcurl path. Stable HTTP/3, QUIC, header, and QUIC TLS fields are compared with the profile's `http3` section in `signatures/`.
+* A packet capture is started on the loopback interface while `curl-impersonate` is run with the relevant wrapper script against a local `nghttpd` server (a simple HTTP/2 server with TLS). The Client Hello message is extracted from the capture and compared against the known signature of the browser. Capturing against a local server keeps the test independent of external websites, and loopback traffic is never fragmented, so even large Client Hello messages (e.g. with post-quantum key shares) are parsed reliably.
+* `curl-impersonate` is run, connecting to the same local `nghttpd` server. The HTTP/2 pseudo-headers and headers are extracted from the output log of `nghttpd` and compared to the known headers of the browser.
+* HTTP/3-enabled profiles connect to `https://fp.impersonate.pro/api/http3` with both the wrapper and the `CURL_IMPERSONATE`/`LD_PRELOAD` libcurl path. Stable HTTP/3, QUIC, header, and QUIC TLS fields are compared with the profile's `http3` section in `signatures/`. These are the only tests that require internet access; they are marked with the `remote` pytest marker and can be skipped with `pytest -m "not remote"`.
 * The same HTTP/3 clients connect in fallback mode to the local HTTP/2-only server, and the resulting HTTP/2 signature is checked.
 
 ## What's missing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,12 @@
+import sys
+
+
 def pytest_addoption(parser):
     # Where to find curl-impersonate's binaries
     parser.addoption("--install-dir", action="store", default="/usr/local")
-    parser.addoption("--capture-interface", action="store", default="eth0")
+    # Captures run against a local server, so default to loopback.
+    parser.addoption(
+        "--capture-interface",
+        action="store",
+        default="lo0" if sys.platform == "darwin" else "lo",
+    )

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 asyncio_mode = auto
+markers =
+    remote: requires internet access to a remote fingerprint server (deselect with '-m "not remote"')

--- a/tests/test_impersonate.py
+++ b/tests/test_impersonate.py
@@ -1,21 +1,23 @@
-import os
-import sys
-import json
-import random
-import logging
-import pathlib
-import subprocess
-import tempfile
-import itertools
 import asyncio
+import io
+import itertools
+import json
+import logging
+import os
+import pathlib
+import socket
+import subprocess
+import sys
+import tempfile
+import time
 
-import yaml
+import dpkt
 import pytest
-from th1.tls.parser import parse_pcap
-from th1.tls.signature import TLSClientHelloSignature
+import yaml
 from th1.http2.parser import parse_nghttpd_log
 from th1.http2.signature import HTTP2Signature
-import dpkt
+from th1.tls.parser import parse_pcap
+from th1.tls.signature import TLSClientHelloSignature
 
 
 @pytest.fixture
@@ -44,21 +46,7 @@ a real browser, by comparing with known signatures
 # This ensures we will capture the correct traffic in tcpdump.
 LOCAL_PORTS = (50000, 50100)
 
-
-# https://docs.github.com/en/actions/learn-github-actions/variables
-logging.debug("$CI is: %s", os.getenv("CI"))
-TEST_URLS = [
-    "https://www.wikimedia.org",
-    "https://www.wikipedia.org",
-    "https://www.mozilla.org/en-US/",
-    "https://www.apache.org",
-    # "https://www.kernel.org",
-    "https://git-scm.com",
-]
-# TEST_URLS = [
-#     "https://tls.browserleaks.com/json",
-#     "https://httpbin.org/ip",
-# ]
+SERVER_PORT = 8443
 
 # List of binaries and their expected signatures
 CURL_BINARIES_AND_SIGNATURES = yaml.safe_load(open("./targets.yaml"))
@@ -87,14 +75,8 @@ for path in pathlib.Path("signatures").glob("**/*.yaml"):
 
 
 @pytest.fixture
-def test_urls():
-    # Shuffle TEST_URLS randomly
-    return random.sample(TEST_URLS, k=len(TEST_URLS))
-
-
-@pytest.fixture
 def tcpdump(pytestconfig):
-    """Initialize a sniffer to capture curl's traffic."""
+    """Initialize a sniffer to capture curl's traffic to the local server."""
     interface = pytestconfig.getoption("capture_interface")
 
     logging.debug(f"Running tcpdump on interface {interface}")
@@ -111,15 +93,17 @@ def tcpdump(pytestconfig):
             "-",
             "-U",  # Important, makes tcpdump unbuffered
             (
-                f"(tcp src portrange {LOCAL_PORTS[0]}-{LOCAL_PORTS[1]}"
-                f" and tcp dst port 443) or"
-                f"(tcp dst portrange {LOCAL_PORTS[0]}-{LOCAL_PORTS[1]}"
-                f" and tcp src port 443)"
+                f"tcp src portrange {LOCAL_PORTS[0]}-{LOCAL_PORTS[1]}"
+                f" and tcp dst port {SERVER_PORT}"
             ),
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
+
+    # Wait for "listening on ..." so curl doesn't run before the capture is active
+    line = p.stderr.readline()
+    logging.debug("tcpdump: %s", line.decode("utf-8", errors="replace").rstrip())
 
     yield p
 
@@ -195,6 +179,50 @@ async def nghttpd():
     await proc.wait()
 
 
+def _extract_client_hellos(pcap: bytes, port: int = SERVER_PORT) -> list[dict]:
+    """Extract TLS Client Hello records from a loopback capture.
+
+    th1's ``parse_pcap`` assumes Ethernet framing; macOS/BSD loopback
+    captures use DLT_NULL (a 4-byte protocol family header per packet),
+    so parse the IP payload directly in that case.
+    """
+    reader = dpkt.pcap.Reader(io.BytesIO(pcap))
+    if reader.datalink() != dpkt.pcap.DLT_NULL:
+        return parse_pcap(pcap, port=port)
+
+    client_hellos = []
+    for _, buf in reader:
+        # Host byte order, OS-specific AF_* values
+        family = int.from_bytes(buf[:4], sys.byteorder)
+        try:
+            if family == socket.AF_INET:
+                ip = dpkt.ip.IP(buf[4:])
+            elif family == socket.AF_INET6:
+                ip = dpkt.ip6.IP6(buf[4:])
+            else:
+                continue
+        except dpkt.UnpackError:
+            continue
+        if not isinstance(ip.data, dpkt.tcp.TCP):
+            continue
+        tcp = ip.data
+        if tcp.dport != port or not tcp.data:
+            continue
+        tls = dpkt.ssl.TLSRecord(tcp.data)
+        if tls.type != 0x16:  # Handshake
+            continue
+        handshake = dpkt.ssl.TLSHandshake(tls.data)
+        if handshake.type != 0x01:  # Client Hello
+            continue
+        client_hellos.append(
+            {
+                "client_hello": tcp.data,
+                "signature": TLSClientHelloSignature.from_bytes(tcp.data),
+            }
+        )
+    return client_hellos
+
+
 def _set_ld_preload(env_vars, lib):
     if sys.platform.startswith("linux"):
         env_vars["LD_PRELOAD"] = lib + ".so"
@@ -237,23 +265,24 @@ def _run_curl(curl_binary, env_vars, extra_args, urls, output="/dev/null"):
     "curl_binary, env_vars, ld_preload, expected_signature",
     CURL_BINARIES_AND_SIGNATURES,
 )
-def test_tls_client_hello(
+async def test_tls_client_hello(
     pytestconfig,
     tcpdump,
+    nghttpd,
     curl_binary,
     env_vars,
     ld_preload,
     browser_signatures,
     expected_signature,
-    test_urls,
 ):
     """
     Check that curl's TLS signature is identical to that of a
     real browser.
 
-    Launches curl while sniffing its TLS traffic with tcpdump. Then
-    extracts the Client Hello packet from the capture and compares its
-    signature with the expected one defined in the YAML database.
+    Launches curl against the local TLS server while sniffing its traffic
+    with tcpdump on the loopback interface. Then extracts the Client Hello
+    packets from the capture and compares their signature with the expected
+    one defined in the YAML database.
     """
     curl_binary = os.path.join(
         pytestconfig.getoption("install_dir"), "bin", curl_binary
@@ -270,33 +299,32 @@ def test_tls_client_hello(
             os.path.join(pytestconfig.getoption("install_dir"), "lib", ld_preload),
         )
 
-    test_urls = test_urls[0:2]
-    ret = _run_curl(curl_binary, env_vars=env_vars, extra_args=None, urls=test_urls)
-    assert ret == 0
-
-    try:
-        pcap, stderr = tcpdump.communicate(timeout=5)
-
-        # If tcpdump finished running before timeout, it's likely it failed
-        # with an error.
-        assert tcpdump.returncode == 0, (
-            f"tcpdump failed with error code {tcpdump.returncode}, " f"stderr: {stderr}"
+    # Separate processes cannot resume TLS sessions
+    expected_hellos = 2
+    for _ in range(expected_hellos):
+        ret = _run_curl(
+            curl_binary,
+            env_vars=env_vars,
+            extra_args=["-k"],
+            urls=[f"https://localhost:{SERVER_PORT}"],
         )
-    except subprocess.TimeoutExpired:
-        tcpdump.kill()
-        pcap, stderr = tcpdump.communicate(timeout=3)
+        assert ret == 0
 
-    assert len(pcap) > 0
+    # Let tcpdump flush before stopping
+    time.sleep(0.5)
+    tcpdump.terminate()
+    pcap, stderr = tcpdump.communicate(timeout=10)
+
+    assert len(pcap) > 0, f"tcpdump produced no capture, stderr: {stderr}"
     logging.debug(f"Captured pcap of length {len(pcap)} bytes")
 
-    try:
-        client_hellos = parse_pcap(pcap)
-    except dpkt.NeedData:
-        logging.error("DPKT does not support Chrome 124 yet.")
-        return
+    client_hellos = _extract_client_hellos(pcap)
 
-    # A client hello message for each URL
-    assert len(client_hellos) == len(test_urls)
+    # A client hello message for each curl invocation
+    assert len(client_hellos) == expected_hellos, (
+        f"Expected {expected_hellos} Client Hello messages, "
+        f"found {len(client_hellos)}; tcpdump stderr: {stderr}"
+    )
 
     logging.debug(
         f"Found {len(client_hellos)} Client Hello messages, "
@@ -372,6 +400,7 @@ async def test_http2_headers(
     assert equals, msg
 
 
+@pytest.mark.remote
 @pytest.mark.parametrize(
     "curl_binary, env_vars, ld_preload, profile", HTTP3_CLIENTS
 )


### PR DESCRIPTION
Part of #244. The TLS signature test now captures on loopback against the local `nghttpd` server instead of external websites. Loopback packets are never fragmented, so the `dpkt.NeedData` escape hatch that silently skipped the TLS check for Chrome 124+ profiles is gone. Also fixes two tcpdump races and handles `DLT_NULL` captures, so the suite runs on macOS.

`test_http3_fingerprint` is the only test left needing internet; it is marked `remote`. A local variant needs a QUIC-aware parser in th1 — follow-up for the first checkbox of #244.

CI: native parallel test jobs for x86_64, aarch64 and arm64 macOS; DockerHub login skipped on fork PRs, where missing secrets failed the job; actions bumped to latest for the Node 20 deprecation.