### PR TITLE
cmake: pre-set HAVE_DES_ECB_ENCRYPT for CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,6 +562,7 @@ ExternalProject_Add(curl
       -DCURL_ENABLE_SSL=ON
       ${_curl_openssl_flags}
       # Bypass BoringSSL check
+      -DHAVE_DES_ECB_ENCRYPT=1
       -DHAVE_SSL_SET0_WBIO=1
       -DHAVE_SSL_SET1_ECH_CONFIG_LIST=1
       -DHAVE_SSL_SET_QUIC_USE_LEGACY_CODEPOINT=1


### PR DESCRIPTION
Hi,

Configure fails under CMake 4: `curl_openssl_check_exists()` runs `try_compile`
with imported OpenSSL targets the scratch project doesn't have. The other two
`USE_OPENSSL` checks are already pre-set here, this was the last one running.
BoringSSL exports `DES_ecb_encrypt`.

Tested with CMake 4.3.4 and 3.28.3.
